### PR TITLE
As a group member I can delete a meeting #65

### DIFF
--- a/src/main/java/syncsquad/teamsync/logic/Messages.java
+++ b/src/main/java/syncsquad/teamsync/logic/Messages.java
@@ -15,6 +15,7 @@ public class Messages {
     public static final String MESSAGE_UNKNOWN_COMMAND = "Unknown command";
     public static final String MESSAGE_INVALID_COMMAND_FORMAT = "Invalid command format! \n%1$s";
     public static final String MESSAGE_INVALID_PERSON_DISPLAYED_INDEX = "The person index provided is invalid";
+    public static final String MESSAGE_INVALID_MEETING_DISPLAYED_INDEX = "The meeting index provided is invalid";
     public static final String MESSAGE_PERSONS_LISTED_OVERVIEW = "%1$d persons listed!";
     public static final String MESSAGE_DUPLICATE_FIELDS =
                 "Multiple values specified for the following single-valued field(s): ";

--- a/src/main/java/syncsquad/teamsync/logic/commands/DeleteMeetingCommand.java
+++ b/src/main/java/syncsquad/teamsync/logic/commands/DeleteMeetingCommand.java
@@ -1,0 +1,67 @@
+package syncsquad.teamsync.logic.commands;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.List;
+
+import syncsquad.teamsync.commons.core.index.Index;
+import syncsquad.teamsync.logic.Messages;
+import syncsquad.teamsync.logic.commands.exceptions.CommandException;
+import syncsquad.teamsync.model.Model;
+import syncsquad.teamsync.model.meeting.Meeting;
+
+/**
+ * Deletes a person identified using its displayed index from the address book.
+ */
+public class DeleteMeetingCommand extends Command {
+    public static final String COMMAND_WORD = "delmeeting";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD
+            + ": Deletes the meeting identified by the index number used in the displayed meeting list"
+            + "Parameters: INDEX (must be a positive integer)\n"
+            + "Example: " + COMMAND_WORD + " 1";
+
+    public static final String MESSAGE_DELETE_MEETING_SUCCESS = "Deleted Meeting: %1$s";
+
+    private final Index targetIndex;
+
+    /**
+     * Creates a DeleteMeetingCommand to delete the meeting at the specified {@code targetIndex}
+     */
+    public DeleteMeetingCommand(Index targetIndex) {
+        requireNonNull(targetIndex);
+        this.targetIndex = targetIndex;
+    }
+
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+        requireNonNull(model);
+        List<Meeting> lastShownList = model.getMeetingList();
+
+        if (targetIndex.getZeroBased() >= lastShownList.size()) {
+            throw new CommandException(Messages.MESSAGE_INVALID_MEETING_DISPLAYED_INDEX);
+        }
+
+        Meeting meetingToDelete = lastShownList.get(targetIndex.getZeroBased());
+        model.deleteMeeting(meetingToDelete);
+        return new CommandResult(String.format(MESSAGE_DELETE_MEETING_SUCCESS, meetingToDelete));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        // short circuit if same object
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof DeleteMeetingCommand)) {
+            return false;
+        }
+
+        // state check
+        DeleteMeetingCommand otherDeleteMeetingCommand = (DeleteMeetingCommand) other;
+        return targetIndex.equals(otherDeleteMeetingCommand.targetIndex);
+    }
+
+}

--- a/src/main/java/syncsquad/teamsync/logic/parser/AddMeetingCommandParser.java
+++ b/src/main/java/syncsquad/teamsync/logic/parser/AddMeetingCommandParser.java
@@ -9,7 +9,7 @@ import syncsquad.teamsync.model.meeting.Meeting;
 /**
  * Parses input arguments and creates a new AddMeetingCommand object
  */
-public class AddMeetingCommandParser {
+public class AddMeetingCommandParser implements Parser<AddMeetingCommand> {
 
     /**
      * Parses the given {@code String} of arguments in the context of the AddMeetingCommand

--- a/src/main/java/syncsquad/teamsync/logic/parser/AddressBookParser.java
+++ b/src/main/java/syncsquad/teamsync/logic/parser/AddressBookParser.java
@@ -13,6 +13,7 @@ import syncsquad.teamsync.logic.commands.AddMeetingCommand;
 import syncsquad.teamsync.logic.commands.ClearCommand;
 import syncsquad.teamsync.logic.commands.Command;
 import syncsquad.teamsync.logic.commands.DeleteCommand;
+import syncsquad.teamsync.logic.commands.DeleteMeetingCommand;
 import syncsquad.teamsync.logic.commands.EditCommand;
 import syncsquad.teamsync.logic.commands.ExitCommand;
 import syncsquad.teamsync.logic.commands.FindCommand;
@@ -75,6 +76,9 @@ public class AddressBookParser {
 
         case AddMeetingCommand.COMMAND_WORD:
             return new AddMeetingCommandParser().parse(arguments);
+
+        case DeleteMeetingCommand.COMMAND_WORD:
+            return new DeleteMeetingCommandParser().parse(arguments);
 
         case ExitCommand.COMMAND_WORD:
             return new ExitCommand();

--- a/src/main/java/syncsquad/teamsync/logic/parser/DeleteMeetingCommandParser.java
+++ b/src/main/java/syncsquad/teamsync/logic/parser/DeleteMeetingCommandParser.java
@@ -1,0 +1,29 @@
+package syncsquad.teamsync.logic.parser;
+
+import static syncsquad.teamsync.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+
+import syncsquad.teamsync.commons.core.index.Index;
+import syncsquad.teamsync.logic.commands.DeleteMeetingCommand;
+import syncsquad.teamsync.logic.parser.exceptions.ParseException;
+
+/**
+ * Parses input arguments and creates a new DeleteMeetingCommand object
+ */
+public class DeleteMeetingCommandParser implements Parser<DeleteMeetingCommand> {
+
+    /**
+     * Parses the given {@code String} of arguments in the context of the DeleteMeetingCommand
+     * and returns a DeleteMeetingCommand object for execution.
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    public DeleteMeetingCommand parse(String args) throws ParseException {
+        try {
+            Index index = ParserUtil.parseIndex(args);
+            return new DeleteMeetingCommand(index);
+        } catch (ParseException pe) {
+            throw new ParseException(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteMeetingCommand.MESSAGE_USAGE), pe);
+        }
+    }
+
+}

--- a/src/main/java/syncsquad/teamsync/logic/parser/ParserUtil.java
+++ b/src/main/java/syncsquad/teamsync/logic/parser/ParserUtil.java
@@ -38,7 +38,7 @@ public class ParserUtil {
             .toFormatter();
 
     public static final DateTimeFormatter TIME_FORMATTER = new DateTimeFormatterBuilder()
-            .append(DateTimeFormatter.ofPattern("HH:mm"))
+            .append(DateTimeFormatter.ofPattern("H:mm"))
             .parseCaseInsensitive()
             .toFormatter();
 

--- a/src/main/java/syncsquad/teamsync/model/AddressBook.java
+++ b/src/main/java/syncsquad/teamsync/model/AddressBook.java
@@ -126,6 +126,14 @@ public class AddressBook implements ReadOnlyAddressBook {
         meetings.add(meeting);
     }
 
+    /**
+     * Removes {@code key} from this {@code AddressBook}.
+     * {@code key} must exist in the address book.
+     */
+    public void removeMeeting(Meeting key) {
+        meetings.remove(key);
+    }
+
     //// util methods
 
     @Override

--- a/src/main/java/syncsquad/teamsync/model/Model.java
+++ b/src/main/java/syncsquad/teamsync/model/Model.java
@@ -1,6 +1,7 @@
 package syncsquad.teamsync.model;
 
 import java.nio.file.Path;
+import java.util.List;
 import java.util.function.Predicate;
 
 import javafx.collections.ObservableList;
@@ -86,9 +87,6 @@ public interface Model {
      */
     void updateFilteredPersonList(Predicate<Person> predicate);
 
-    /** Returns an unmodifiable view of the list of meetings */
-    ObservableList<Meeting> getMeetingList();
-
     /**
      * Returns true if a meeting with the same date, start time and end time as {@code meeting}
      * exists in the address book.
@@ -100,4 +98,13 @@ public interface Model {
      * {@code meeting} must not already exist in the address book.
      */
     void addMeeting(Meeting meeting);
+
+    /**
+     * Deletes the given meeting.
+     * The meeting must exist in the address book.
+     */
+    void deleteMeeting(Meeting meeting);
+
+    /** Returns an unmodifiable view of the list of meetings */
+    ObservableList<Meeting> getMeetingList();
 }

--- a/src/main/java/syncsquad/teamsync/model/ModelManager.java
+++ b/src/main/java/syncsquad/teamsync/model/ModelManager.java
@@ -121,6 +121,11 @@ public class ModelManager implements Model {
     }
 
     @Override
+    public void deleteMeeting(Meeting target) {
+        addressBook.removeMeeting(target);
+    }
+
+    @Override
     public void addMeeting(Meeting meeting) {
         addressBook.addMeeting(meeting);
     }

--- a/src/main/java/syncsquad/teamsync/model/meeting/UniqueMeetingList.java
+++ b/src/main/java/syncsquad/teamsync/model/meeting/UniqueMeetingList.java
@@ -9,6 +9,7 @@ import java.util.List;
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
 import syncsquad.teamsync.model.meeting.exceptions.DuplicateMeetingException;
+import syncsquad.teamsync.model.meeting.exceptions.MeetingNotFoundException;
 
 /**
  * A list of meetings that enforces uniqueness between its elements and does not allow nulls.
@@ -43,6 +44,17 @@ public class UniqueMeetingList implements Iterable<Meeting> {
             throw new DuplicateMeetingException();
         }
         internalList.add(toAdd);
+    }
+
+    /**
+     * Removes the equivalent person from the list.
+     * The person must exist in the list.
+     */
+    public void remove(Meeting toRemove) {
+        requireNonNull(toRemove);
+        if (!internalList.remove(toRemove)) {
+            throw new MeetingNotFoundException();
+        }
     }
 
     public void setMeetings(UniqueMeetingList replacement) {
@@ -113,4 +125,5 @@ public class UniqueMeetingList implements Iterable<Meeting> {
         }
         return true;
     }
+
 }

--- a/src/main/java/syncsquad/teamsync/model/meeting/exceptions/MeetingNotFoundException.java
+++ b/src/main/java/syncsquad/teamsync/model/meeting/exceptions/MeetingNotFoundException.java
@@ -1,0 +1,6 @@
+package syncsquad.teamsync.model.meeting.exceptions;
+
+/**
+ * Signals that the operation is unable to find the specified meeting.
+ */
+public class MeetingNotFoundException extends RuntimeException {}


### PR DESCRIPTION
Fixes #65

Implements a command to delete meetings.

Note:
* `AddMeetingCommandParser` has been updated to inherit from `Parser<AddMeetingCommand>`
* Parser for time strings has been updated to accept time formats without leading zeroes (i.e. 9:00 is now a valid time string)
* The UI component is not updated to display the meetings list
* Tests have yet to be (re)written

Proposed commit message:
```markdown
Implements a command to delete meetings.

Let's,
* update the Logic component to
  - support a command to delete meetings
  - parse the arguments to the command to delete meetings
* update the Model component to
  - delete Meeting objects from the AddressBook when DeleteMeetingCommand is executed

Note:
* AddMeetingCommandParser has been updated to inherit from Parser<AddMeetingCommand>
* Parser for time strings has been updated to accept time formats without leading zeroes (i.e. 9:00 is now a valid time string)
* The UI component is not updated to display the meetings list
* Tests have yet to be (re)written
```
