### PR TITLE
Check for conflict when adding modules

### DIFF
--- a/src/main/java/syncsquad/teamsync/logic/Messages.java
+++ b/src/main/java/syncsquad/teamsync/logic/Messages.java
@@ -20,6 +20,7 @@ public class Messages {
     public static final String MESSAGE_DUPLICATE_FIELDS =
                 "Multiple values specified for the following single-valued field(s): ";
     public static final String MESSAGE_INVALID_MODULE = "The person does not have the provided module assigned to them";
+    public static final String MESSAGE_INVALID_START_END_TIME = "End time must be after start time";
 
     /**
      * Returns an error message indicating the duplicate prefixes.

--- a/src/main/java/syncsquad/teamsync/logic/commands/AddModuleCommand.java
+++ b/src/main/java/syncsquad/teamsync/logic/commands/AddModuleCommand.java
@@ -34,6 +34,7 @@ public class AddModuleCommand extends Command {
 
     public static final String MESSAGE_SUCCESS = "Added Module to Person: %1$s";
     public static final String MESSAGE_DUPLICATE_MODULE = "This module already exists for the person.";
+    public static final String MESSAGE_OVERLAP_MODULE = "This person already has another module during this period.";
 
     private final Index index;
     private final Module module;
@@ -64,12 +65,26 @@ public class AddModuleCommand extends Command {
             throw new CommandException(MESSAGE_DUPLICATE_MODULE);
         }
         Set<Module> moduleSet = new HashSet<>(personToEdit.getModules());
+
+        // check for overlapping modules
+        if (hasOverlap(moduleSet)) {
+            throw new CommandException(MESSAGE_OVERLAP_MODULE);
+        }
+
         moduleSet.add(module);
         Person newPerson = new Person(personToEdit.getName(), personToEdit.getPhone(),
                 personToEdit.getEmail(), personToEdit.getAddress(), personToEdit.getTags(), moduleSet);
         model.setPerson(personToEdit, newPerson);
         model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
         return new CommandResult(String.format(MESSAGE_SUCCESS, Messages.format(newPerson)));
+    }
+
+    /**
+     * Checks if the module to be added overlaps with existing modules
+     */
+    public boolean hasOverlap(Set<Module> moduleSet) {
+        requireNonNull(moduleSet);
+        return moduleSet.stream().anyMatch(module::isOverlap);
     }
 
     @Override

--- a/src/main/java/syncsquad/teamsync/logic/commands/AddModuleCommand.java
+++ b/src/main/java/syncsquad/teamsync/logic/commands/AddModuleCommand.java
@@ -84,7 +84,7 @@ public class AddModuleCommand extends Command {
      */
     public boolean hasOverlap(Set<Module> moduleSet) {
         requireNonNull(moduleSet);
-        return moduleSet.stream().anyMatch(module::isOverlap);
+        return moduleSet.stream().anyMatch(module::isOverlapping);
     }
 
     @Override

--- a/src/main/java/syncsquad/teamsync/logic/parser/AddModuleCommandParser.java
+++ b/src/main/java/syncsquad/teamsync/logic/parser/AddModuleCommandParser.java
@@ -1,6 +1,7 @@
 package syncsquad.teamsync.logic.parser;
 
 import static syncsquad.teamsync.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static syncsquad.teamsync.logic.Messages.MESSAGE_INVALID_START_END_TIME;
 
 import java.time.LocalTime;
 
@@ -38,9 +39,11 @@ public class AddModuleCommandParser implements Parser<AddModuleCommand> {
         Day day = ParserUtil.parseDay(parameters[2]);
         LocalTime startTime = ParserUtil.parseTime(parameters[3]);
         LocalTime endTime = ParserUtil.parseTime(parameters[4]);
+
         if (!endTime.isAfter(startTime)) {
-            throw new ParseException("End time must be after Start time");
+            throw new ParseException(MESSAGE_INVALID_START_END_TIME);
         }
+
         return new AddModuleCommand(index, new Module(moduleCode, day, startTime, endTime));
     }
 }

--- a/src/main/java/syncsquad/teamsync/model/module/Day.java
+++ b/src/main/java/syncsquad/teamsync/model/module/Day.java
@@ -48,7 +48,7 @@ public class Day {
         }
 
         // instanceof handles nulls
-        if (!(other instanceof Module)) {
+        if (!(other instanceof Day)) {
             return false;
         }
 

--- a/src/main/java/syncsquad/teamsync/model/module/Module.java
+++ b/src/main/java/syncsquad/teamsync/model/module/Module.java
@@ -58,6 +58,18 @@ public class Module {
     }
 
     /**
+     * Returns true if both modules overlap in terms of timing.
+     * Both start and end time are considered to be non-inclusive,
+     * i.e. endTime of 12pm and startTime of 12pm of another module is allowed.
+     */
+    public boolean isOverlap(Module otherModule) {
+        boolean timeOverlap = this.getEndTime().isAfter(otherModule.getStartTime())
+                && this.getStartTime().isBefore(otherModule.getEndTime());
+        boolean dayOverlap = this.getDay().equals(otherModule.getDay());
+        return timeOverlap && dayOverlap;
+    }
+
+    /**
      * Returns true if both modules have the same identity and data fields.
      * This defines a stronger notion of equality between two modules.
      */

--- a/src/main/java/syncsquad/teamsync/model/module/Module.java
+++ b/src/main/java/syncsquad/teamsync/model/module/Module.java
@@ -62,7 +62,7 @@ public class Module {
      * Both start and end time are considered to be non-inclusive,
      * i.e. endTime of 12pm and startTime of 12pm of another module is allowed.
      */
-    public boolean isOverlap(Module otherModule) {
+    public boolean isOverlapping(Module otherModule) {
         boolean timeOverlap = this.getEndTime().isAfter(otherModule.getStartTime())
                 && this.getStartTime().isBefore(otherModule.getEndTime());
         boolean dayOverlap = this.getDay().equals(otherModule.getDay());


### PR DESCRIPTION
Fix #102 

Implements a check to ensure that modules added do not conflict with the person's existing modules. 

Note
- Currently, viewing the details of modules for a person is still not implemented. 