### PR TITLE
Add tests for meeting handling in Model and Storage components #124

### DIFF
--- a/src/main/java/syncsquad/teamsync/logic/Messages.java
+++ b/src/main/java/syncsquad/teamsync/logic/Messages.java
@@ -5,6 +5,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import syncsquad.teamsync.logic.parser.Prefix;
+import syncsquad.teamsync.model.meeting.Meeting;
 import syncsquad.teamsync.model.person.Person;
 
 /**
@@ -51,6 +52,19 @@ public class Messages {
         builder.append("; Tags: ");
         person.getTags().forEach(builder::append);
         return builder.toString();
+    }
+
+    /**
+     * Formats the {@code meeting} for display to the user
+     */
+    public static String format(Meeting meeting) {
+        return new StringBuilder()
+                .append(meeting.getDate())
+                .append("; Start time: ")
+                .append(meeting.getStartTime())
+                .append("; End time: ")
+                .append(meeting.getEndTime())
+                .toString();
     }
 
 }

--- a/src/main/java/syncsquad/teamsync/logic/commands/AddMeetingCommand.java
+++ b/src/main/java/syncsquad/teamsync/logic/commands/AddMeetingCommand.java
@@ -4,6 +4,7 @@ import static java.util.Objects.requireNonNull;
 
 import javafx.collections.ObservableList;
 import syncsquad.teamsync.commons.util.ToStringBuilder;
+import syncsquad.teamsync.logic.Messages;
 import syncsquad.teamsync.logic.commands.exceptions.CommandException;
 import syncsquad.teamsync.model.Model;
 import syncsquad.teamsync.model.meeting.Meeting;
@@ -50,7 +51,7 @@ public class AddMeetingCommand extends Command {
         }
 
         model.addMeeting(toAdd);
-        return new CommandResult(String.format(MESSAGE_SUCCESS, toAdd));
+        return new CommandResult(String.format(MESSAGE_SUCCESS, Messages.format(toAdd)));
     }
 
     /**

--- a/src/main/java/syncsquad/teamsync/logic/commands/DeleteMeetingCommand.java
+++ b/src/main/java/syncsquad/teamsync/logic/commands/DeleteMeetingCommand.java
@@ -45,7 +45,7 @@ public class DeleteMeetingCommand extends Command {
 
         Meeting meetingToDelete = lastShownList.get(targetIndex.getZeroBased());
         model.deleteMeeting(meetingToDelete);
-        return new CommandResult(String.format(MESSAGE_DELETE_MEETING_SUCCESS, meetingToDelete));
+        return new CommandResult(String.format(MESSAGE_DELETE_MEETING_SUCCESS, Messages.format(meetingToDelete)));
     }
 
     @Override

--- a/src/main/java/syncsquad/teamsync/model/AddressBook.java
+++ b/src/main/java/syncsquad/teamsync/model/AddressBook.java
@@ -165,7 +165,7 @@ public class AddressBook implements ReadOnlyAddressBook {
         }
 
         AddressBook otherAddressBook = (AddressBook) other;
-        return persons.equals(otherAddressBook.persons);
+        return persons.equals(otherAddressBook.persons) && meetings.equals(otherAddressBook.meetings);
     }
 
     @Override

--- a/src/main/java/syncsquad/teamsync/model/AddressBook.java
+++ b/src/main/java/syncsquad/teamsync/model/AddressBook.java
@@ -119,6 +119,15 @@ public class AddressBook implements ReadOnlyAddressBook {
     }
 
     /**
+     * Returns true if a meeting with the same date as {@code meeting} and overlapping time range
+     * exists in the address book.
+     */
+    public boolean hasOverlappingMeeting(Meeting meeting) {
+        requireNonNull(meeting);
+        return meetings.hasOverlap(meeting);
+    }
+
+    /**
      * Adds a meeting to the address book.
      * The meeting must not already exist in the meeting book.
      */

--- a/src/main/java/syncsquad/teamsync/model/meeting/Meeting.java
+++ b/src/main/java/syncsquad/teamsync/model/meeting/Meeting.java
@@ -5,6 +5,9 @@ import static syncsquad.teamsync.commons.util.CollectionUtil.requireAllNonNull;
 import java.time.LocalDate;
 import java.time.LocalTime;
 import java.time.format.DateTimeFormatter;
+import java.util.Objects;
+
+import syncsquad.teamsync.commons.util.ToStringBuilder;
 
 /**
  * Represents a Meeting in the address book.
@@ -87,11 +90,6 @@ public class Meeting {
     }
 
     @Override
-    public String toString() {
-        return getDateString() + " from " + getStartTimeString() + " to " + getEndTimeString();
-    }
-
-    @Override
     public boolean equals(Object other) {
         if (other == this) {
             return true;
@@ -109,7 +107,16 @@ public class Meeting {
 
     @Override
     public int hashCode() {
-        return date.hashCode() ^ startTime.hashCode() ^ endTime.hashCode();
+        return Objects.hash(date, startTime, endTime);
+    }
+
+    @Override
+    public String toString() {
+        return new ToStringBuilder(this)
+                .add("date", date)
+                .add("startTime", startTime)
+                .add("endTime", endTime)
+                .toString();
     }
 
 }

--- a/src/main/java/syncsquad/teamsync/model/meeting/UniqueMeetingList.java
+++ b/src/main/java/syncsquad/teamsync/model/meeting/UniqueMeetingList.java
@@ -35,6 +35,14 @@ public class UniqueMeetingList implements Iterable<Meeting> {
     }
 
     /**
+     * Returns true if the list contains a meeting that overlaps with the given argument.
+     */
+    public boolean hasOverlap(Meeting toCheck) {
+        requireNonNull(toCheck);
+        return internalList.stream().anyMatch(toCheck::isOverlapping);
+    }
+
+    /**
      * Adds a meeting to the list.
      * The meeting must not already exist in the list.
      */

--- a/src/main/java/syncsquad/teamsync/storage/JsonAdaptedMeeting.java
+++ b/src/main/java/syncsquad/teamsync/storage/JsonAdaptedMeeting.java
@@ -8,6 +8,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 import syncsquad.teamsync.commons.exceptions.IllegalValueException;
 import syncsquad.teamsync.logic.parser.ParserUtil;
+import syncsquad.teamsync.logic.parser.exceptions.ParseException;
 import syncsquad.teamsync.model.meeting.Meeting;
 
 /**
@@ -15,7 +16,12 @@ import syncsquad.teamsync.model.meeting.Meeting;
  */
 class JsonAdaptedMeeting {
 
-    public static final String MISSING_FIELD_MESSAGE_FORMAT = "Person's %s field is missing!";
+    public static final String MISSING_FIELD_MESSAGE_FORMAT = "Meeting's %s field is missing!";
+
+    /** Field names used in missing field error message */
+    public static final String DATE_FIELD = "Date";
+    public static final String START_TIME_FIELD = "StartTime";
+    public static final String END_TIME_FIELD = "EndTime";
 
     private final String date;
     private final String startTime;
@@ -47,11 +53,24 @@ class JsonAdaptedMeeting {
      * @throws IllegalValueException if there were any data constraints violated in the adapted person.
      */
     public Meeting toModelType() throws IllegalValueException {
-        final LocalDate date = ParserUtil.parseDate(this.date);
-        final LocalTime startTime = ParserUtil.parseTime(this.startTime);
-        final LocalTime endTime = ParserUtil.parseTime(this.endTime);
+        if (date == null) {
+            throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT, DATE_FIELD));
+        }
+        if (startTime == null) {
+            throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT, START_TIME_FIELD));
+        }
+        if (endTime == null) {
+            throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT, END_TIME_FIELD));
+        }
 
-        return new Meeting(date, startTime, endTime);
+        try {
+            final LocalDate date = ParserUtil.parseDate(this.date);
+            final LocalTime startTime = ParserUtil.parseTime(this.startTime);
+            final LocalTime endTime = ParserUtil.parseTime(this.endTime);
+            return new Meeting(date, startTime, endTime);
+        } catch (ParseException e) {
+            throw new IllegalValueException(Meeting.MESSAGE_CONSTRAINTS);
+        }
     }
 
 }

--- a/src/main/java/syncsquad/teamsync/storage/JsonSerializableAddressBook.java
+++ b/src/main/java/syncsquad/teamsync/storage/JsonSerializableAddressBook.java
@@ -22,6 +22,7 @@ class JsonSerializableAddressBook {
 
     public static final String MESSAGE_DUPLICATE_PERSON = "Persons list contains duplicate person(s).";
     public static final String MESSAGE_DUPLICATE_MEETING = "Meetings list contains duplicate meeting(s).";
+    public static final String MESSAGE_OVERLAPPING_MEETING = "Meetings list contains overlapping meeting(s).";
 
     private final List<JsonAdaptedPerson> persons = new ArrayList<>();
     private final List<JsonAdaptedMeeting> meetings = new ArrayList<>();
@@ -64,6 +65,9 @@ class JsonSerializableAddressBook {
             Meeting meeting = jsonAdaptedMeeting.toModelType();
             if (addressBook.hasMeeting(meeting)) {
                 throw new IllegalValueException(MESSAGE_DUPLICATE_MEETING);
+            }
+            if (addressBook.hasOverlappingMeeting(meeting)) {
+                throw new IllegalValueException(MESSAGE_OVERLAPPING_MEETING);
             }
             addressBook.addMeeting(meeting);
         }

--- a/src/test/data/JsonAddressBookStorageTest/invalidAndValidMeetingAddressBook.json
+++ b/src/test/data/JsonAddressBookStorageTest/invalidAndValidMeetingAddressBook.json
@@ -1,0 +1,12 @@
+{
+  "persons" : [ ],
+  "meetings" : [ {
+    "date" : "15-04-2025",
+    "startTime" : "Invalid start time",
+    "endTime" : "18:00"
+  }, {
+    "date" : "30-05-2025",
+    "startTime" : "14:00",
+    "endTime" : "15:00"
+  } ]
+}

--- a/src/test/data/JsonAddressBookStorageTest/invalidMeetingAddressBook.json
+++ b/src/test/data/JsonAddressBookStorageTest/invalidMeetingAddressBook.json
@@ -1,0 +1,8 @@
+{
+  "persons" : [ ],
+  "meetings" : [ {
+    "date" : "Invalid date",
+    "startTime" : "14:00",
+    "endTime" : "16:00"
+  } ]
+}

--- a/src/test/data/JsonSerializableAddressBookTest/duplicateMeetingAddressBook.json
+++ b/src/test/data/JsonSerializableAddressBookTest/duplicateMeetingAddressBook.json
@@ -1,0 +1,12 @@
+{
+  "persons" : [ ],
+  "meetings" : [ {
+    "date" : "12-04-2025",
+    "startTime" : "11:00",
+    "endTime" : "13:00"
+  }, {
+    "date" : "12-04-2025",
+    "startTime" : "11:00",
+    "endTime" : "13:00"
+  } ]
+}

--- a/src/test/data/JsonSerializableAddressBookTest/invalidMeetingAddressBook.json
+++ b/src/test/data/JsonSerializableAddressBookTest/invalidMeetingAddressBook.json
@@ -1,0 +1,8 @@
+{
+  "persons" : [ ],
+  "meetings" : [ {
+    "date" : "10-04-2025",
+    "startTime" : "17:30",
+    "endTime" : "Invalid end time"
+  } ]
+}

--- a/src/test/data/JsonSerializableAddressBookTest/overlappingMeetingAddressBook.json
+++ b/src/test/data/JsonSerializableAddressBookTest/overlappingMeetingAddressBook.json
@@ -1,0 +1,12 @@
+{
+  "persons" : [ ],
+  "meetings" : [ {
+    "date" : "12-12-2025",
+    "startTime" : "12:00",
+    "endTime" : "19:00"
+  }, {
+    "date" : "12-12-2025",
+    "startTime" : "18:00",
+    "endTime" : "23:00"
+  } ]
+}

--- a/src/test/data/JsonSerializableAddressBookTest/typicalMeetingsAddressBook.json
+++ b/src/test/data/JsonSerializableAddressBookTest/typicalMeetingsAddressBook.json
@@ -1,0 +1,29 @@
+{
+  "_comment": "AddressBook save file which contains the same Meeting values as in TypicalPersons#getTypicalAddressBook()",
+  "persons" : [ ],
+  "meetings" : [ {
+    "date" : "01-01-2025",
+    "startTime" : "01:00",
+    "endTime" : "04:30"
+  }, {
+    "date" : "02-02-2025",
+    "startTime" : "03:00",
+    "endTime" : "05:55"
+  }, {
+    "date" : "03-03-2025",
+    "startTime" : "04:45",
+    "endTime" : "10:59"
+  }, {
+    "date" : "04-04-2025",
+    "startTime" : "12:55",
+    "endTime" : "16:00"
+  }, {
+    "date" : "05-05-2025",
+    "startTime" : "18:00",
+    "endTime" : "21:00"
+  }, {
+    "date" : "06-06-2025",
+    "startTime" : "20:00",
+    "endTime" : "23:59"
+  } ]
+}

--- a/src/test/java/syncsquad/teamsync/logic/commands/AddMeetingCommandTest.java
+++ b/src/test/java/syncsquad/teamsync/logic/commands/AddMeetingCommandTest.java
@@ -16,6 +16,7 @@ import org.junit.jupiter.api.Test;
 
 import javafx.collections.ObservableList;
 import syncsquad.teamsync.commons.core.GuiSettings;
+import syncsquad.teamsync.logic.Messages;
 import syncsquad.teamsync.logic.commands.exceptions.CommandException;
 import syncsquad.teamsync.model.AddressBook;
 import syncsquad.teamsync.model.Model;
@@ -40,7 +41,7 @@ public class AddMeetingCommandTest {
 
         CommandResult commandResult = new AddMeetingCommand(validMeeting).execute(modelStub);
 
-        assertEquals(String.format(AddMeetingCommand.MESSAGE_SUCCESS, validMeeting),
+        assertEquals(String.format(AddMeetingCommand.MESSAGE_SUCCESS, Messages.format(validMeeting)),
                 commandResult.getFeedbackToUser());
         assertEquals(Arrays.asList(validMeeting), modelStub.meetingsAdded);
     }

--- a/src/test/java/syncsquad/teamsync/logic/commands/CommandTestUtil.java
+++ b/src/test/java/syncsquad/teamsync/logic/commands/CommandTestUtil.java
@@ -54,13 +54,13 @@ public class CommandTestUtil {
     public static final String INVALID_ADDRESS_DESC = " " + PREFIX_ADDRESS; // empty string not allowed for addresses
     public static final String INVALID_TAG_DESC = " " + PREFIX_TAG + "hubby*"; // '*' not allowed in tags
 
-    public static final String VALID_DATE_MAR_MEETING = "03-03-2025";
-    public static final String VALID_START_TIME_MAR_MEETING = "16:00";
-    public static final String VALID_END_TIME_MAR_MEETING = "19:23";
+    public static final String VALID_DATE_SEP_MEETING = "09-09-2025";
+    public static final String VALID_START_TIME_SEP_MEETING = "16:00";
+    public static final String VALID_END_TIME_SEP_MEETING = "19:23";
 
-    public static final String DATE_DESC_MAR_MEETING = " " + VALID_DATE_MAR_MEETING;
-    public static final String START_TIME_DESC_MAR_MEETING = " " + VALID_START_TIME_MAR_MEETING;
-    public static final String END_TIME_DESC_MAR_MEETING = " " + VALID_END_TIME_MAR_MEETING;
+    public static final String DATE_DESC_SEP_MEETING = " " + VALID_DATE_SEP_MEETING;
+    public static final String START_TIME_DESC_SEP_MEETING = " " + VALID_START_TIME_SEP_MEETING;
+    public static final String END_TIME_DESC_SEP_MEETING = " " + VALID_END_TIME_SEP_MEETING;
 
     /* date must be in dd-mm-yyyy format; yyyy is optional */
     public static final String INVALID_DATE_DESC = " " + "tomorrow";

--- a/src/test/java/syncsquad/teamsync/logic/commands/DeleteMeetingCommandTest.java
+++ b/src/test/java/syncsquad/teamsync/logic/commands/DeleteMeetingCommandTest.java
@@ -31,7 +31,8 @@ public class DeleteMeetingCommandTest {
         Meeting meetingToDelete = model.getMeetingList().get(INDEX_FIRST.getZeroBased());
         DeleteMeetingCommand deleteMeetingCommand = new DeleteMeetingCommand(INDEX_FIRST);
 
-        String expectedMessage = String.format(DeleteMeetingCommand.MESSAGE_DELETE_MEETING_SUCCESS, meetingToDelete);
+        String expectedMessage = String.format(DeleteMeetingCommand.MESSAGE_DELETE_MEETING_SUCCESS,
+                Messages.format(meetingToDelete));
 
         ModelManager expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
         expectedModel.deleteMeeting(meetingToDelete);

--- a/src/test/java/syncsquad/teamsync/logic/parser/AddMeetingCommandParserTest.java
+++ b/src/test/java/syncsquad/teamsync/logic/parser/AddMeetingCommandParserTest.java
@@ -1,18 +1,18 @@
 package syncsquad.teamsync.logic.parser;
 
 import static syncsquad.teamsync.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
-import static syncsquad.teamsync.logic.commands.CommandTestUtil.DATE_DESC_MAR_MEETING;
-import static syncsquad.teamsync.logic.commands.CommandTestUtil.END_TIME_DESC_MAR_MEETING;
+import static syncsquad.teamsync.logic.commands.CommandTestUtil.DATE_DESC_SEP_MEETING;
+import static syncsquad.teamsync.logic.commands.CommandTestUtil.END_TIME_DESC_SEP_MEETING;
 import static syncsquad.teamsync.logic.commands.CommandTestUtil.INVALID_DATE_DESC;
 import static syncsquad.teamsync.logic.commands.CommandTestUtil.INVALID_TIME_DESC;
 import static syncsquad.teamsync.logic.commands.CommandTestUtil.PREAMBLE_WHITESPACE;
-import static syncsquad.teamsync.logic.commands.CommandTestUtil.START_TIME_DESC_MAR_MEETING;
-import static syncsquad.teamsync.logic.commands.CommandTestUtil.VALID_DATE_MAR_MEETING;
-import static syncsquad.teamsync.logic.commands.CommandTestUtil.VALID_END_TIME_MAR_MEETING;
-import static syncsquad.teamsync.logic.commands.CommandTestUtil.VALID_START_TIME_MAR_MEETING;
+import static syncsquad.teamsync.logic.commands.CommandTestUtil.START_TIME_DESC_SEP_MEETING;
+import static syncsquad.teamsync.logic.commands.CommandTestUtil.VALID_DATE_SEP_MEETING;
+import static syncsquad.teamsync.logic.commands.CommandTestUtil.VALID_END_TIME_SEP_MEETING;
+import static syncsquad.teamsync.logic.commands.CommandTestUtil.VALID_START_TIME_SEP_MEETING;
 import static syncsquad.teamsync.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static syncsquad.teamsync.logic.parser.CommandParserTestUtil.assertParseSuccess;
-import static syncsquad.teamsync.testutil.TypicalAddressBook.MAR_MEETING;
+import static syncsquad.teamsync.testutil.TypicalAddressBook.SEP_MEETING;
 
 import org.junit.jupiter.api.Test;
 
@@ -25,24 +25,24 @@ public class AddMeetingCommandParserTest {
 
     @Test
     public void parse_allFieldsPresent_success() {
-        Meeting expectedMeeting = new MeetingBuilder(MAR_MEETING).build();
+        Meeting expectedMeeting = new MeetingBuilder(SEP_MEETING).build();
 
         // whitespace only preamble
-        assertParseSuccess(parser, PREAMBLE_WHITESPACE + DATE_DESC_MAR_MEETING + START_TIME_DESC_MAR_MEETING
-                + END_TIME_DESC_MAR_MEETING, new AddMeetingCommand(expectedMeeting));
+        assertParseSuccess(parser, PREAMBLE_WHITESPACE + DATE_DESC_SEP_MEETING + START_TIME_DESC_SEP_MEETING
+                + END_TIME_DESC_SEP_MEETING, new AddMeetingCommand(expectedMeeting));
     }
 
     @Test
     public void parse_repeatedFields_failure() {
-        String validExpectedMeetingString = DATE_DESC_MAR_MEETING + START_TIME_DESC_MAR_MEETING
-                + END_TIME_DESC_MAR_MEETING;
+        String validExpectedMeetingString = DATE_DESC_SEP_MEETING + START_TIME_DESC_SEP_MEETING
+                + END_TIME_DESC_SEP_MEETING;
         String expectedMessage = String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddMeetingCommand.MESSAGE_USAGE);
 
         // multiple dates
-        assertParseFailure(parser, DATE_DESC_MAR_MEETING + validExpectedMeetingString, expectedMessage);
+        assertParseFailure(parser, DATE_DESC_SEP_MEETING + validExpectedMeetingString, expectedMessage);
 
         // extra times
-        assertParseFailure(parser, validExpectedMeetingString + START_TIME_DESC_MAR_MEETING, expectedMessage);
+        assertParseFailure(parser, validExpectedMeetingString + START_TIME_DESC_SEP_MEETING, expectedMessage);
     }
 
     @Test
@@ -50,23 +50,23 @@ public class AddMeetingCommandParserTest {
         String expectedMessage = String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddMeetingCommand.MESSAGE_USAGE);
 
         // missing date
-        assertParseFailure(parser, VALID_START_TIME_MAR_MEETING + VALID_END_TIME_MAR_MEETING, expectedMessage);
+        assertParseFailure(parser, VALID_START_TIME_SEP_MEETING + VALID_END_TIME_SEP_MEETING, expectedMessage);
 
         // missing either start or end time
-        assertParseFailure(parser, VALID_DATE_MAR_MEETING + VALID_START_TIME_MAR_MEETING, expectedMessage);
+        assertParseFailure(parser, VALID_DATE_SEP_MEETING + VALID_START_TIME_SEP_MEETING, expectedMessage);
 
         // missing both start and end time
-        assertParseFailure(parser, VALID_DATE_MAR_MEETING, expectedMessage);
+        assertParseFailure(parser, VALID_DATE_SEP_MEETING, expectedMessage);
     }
 
     @Test
     public void parse_invalidValue_failure() {
         // invalid date
-        assertParseFailure(parser, INVALID_DATE_DESC + START_TIME_DESC_MAR_MEETING + END_TIME_DESC_MAR_MEETING,
+        assertParseFailure(parser, INVALID_DATE_DESC + START_TIME_DESC_SEP_MEETING + END_TIME_DESC_SEP_MEETING,
                 ParserUtil.MESSAGE_INVALID_DATE_FORMAT);
 
         // invalid phone
-        assertParseFailure(parser, DATE_DESC_MAR_MEETING + INVALID_TIME_DESC + END_TIME_DESC_MAR_MEETING,
+        assertParseFailure(parser, DATE_DESC_SEP_MEETING + INVALID_TIME_DESC + END_TIME_DESC_SEP_MEETING,
                 ParserUtil.MESSAGE_INVALID_TIME_FORMAT);
     }
 }

--- a/src/test/java/syncsquad/teamsync/model/meeting/MeetingTest.java
+++ b/src/test/java/syncsquad/teamsync/model/meeting/MeetingTest.java
@@ -3,9 +3,9 @@ package syncsquad.teamsync.model.meeting;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static syncsquad.teamsync.logic.commands.CommandTestUtil.VALID_DATE_MAR_MEETING;
-import static syncsquad.teamsync.logic.commands.CommandTestUtil.VALID_END_TIME_MAR_MEETING;
-import static syncsquad.teamsync.logic.commands.CommandTestUtil.VALID_START_TIME_MAR_MEETING;
+import static syncsquad.teamsync.logic.commands.CommandTestUtil.VALID_DATE_SEP_MEETING;
+import static syncsquad.teamsync.logic.commands.CommandTestUtil.VALID_END_TIME_SEP_MEETING;
+import static syncsquad.teamsync.logic.commands.CommandTestUtil.VALID_START_TIME_SEP_MEETING;
 import static syncsquad.teamsync.testutil.TypicalAddressBook.FEB_MEETING;
 import static syncsquad.teamsync.testutil.TypicalAddressBook.JAN_MEETING;
 
@@ -34,15 +34,15 @@ public class MeetingTest {
         assertFalse(JAN_MEETING.equals(FEB_MEETING));
 
         // different date -> returns false
-        Meeting editedJanMeeting = new MeetingBuilder(JAN_MEETING).withDate(VALID_DATE_MAR_MEETING).build();
+        Meeting editedJanMeeting = new MeetingBuilder(JAN_MEETING).withDate(VALID_DATE_SEP_MEETING).build();
         assertFalse(JAN_MEETING.equals(editedJanMeeting));
 
         // different start time -> returns false
-        editedJanMeeting = new MeetingBuilder(JAN_MEETING).withStartTime(VALID_START_TIME_MAR_MEETING).build();
+        editedJanMeeting = new MeetingBuilder(JAN_MEETING).withStartTime(VALID_START_TIME_SEP_MEETING).build();
         assertFalse(JAN_MEETING.equals(editedJanMeeting));
 
         // different end time -> returns false
-        editedJanMeeting = new MeetingBuilder(JAN_MEETING).withEndTime(VALID_END_TIME_MAR_MEETING).build();
+        editedJanMeeting = new MeetingBuilder(JAN_MEETING).withEndTime(VALID_END_TIME_SEP_MEETING).build();
         assertFalse(JAN_MEETING.equals(editedJanMeeting));
     }
 

--- a/src/test/java/syncsquad/teamsync/model/meeting/MeetingTest.java
+++ b/src/test/java/syncsquad/teamsync/model/meeting/MeetingTest.java
@@ -48,7 +48,7 @@ public class MeetingTest {
 
     @Test
     public void toStringMethod() {
-        String expected = Meeting.class.getCanonicalName() + "{date=" +  JAN_MEETING.getDate()
+        String expected = Meeting.class.getCanonicalName() + "{date=" + JAN_MEETING.getDate()
                 + ", startTime=" + JAN_MEETING.getStartTime() + ", endTime=" + JAN_MEETING.getEndTime() + "}";
         assertEquals(expected, JAN_MEETING.toString());
     }

--- a/src/test/java/syncsquad/teamsync/model/meeting/MeetingTest.java
+++ b/src/test/java/syncsquad/teamsync/model/meeting/MeetingTest.java
@@ -1,0 +1,55 @@
+package syncsquad.teamsync.model.meeting;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static syncsquad.teamsync.logic.commands.CommandTestUtil.VALID_DATE_MAR_MEETING;
+import static syncsquad.teamsync.logic.commands.CommandTestUtil.VALID_END_TIME_MAR_MEETING;
+import static syncsquad.teamsync.logic.commands.CommandTestUtil.VALID_START_TIME_MAR_MEETING;
+import static syncsquad.teamsync.testutil.TypicalAddressBook.FEB_MEETING;
+import static syncsquad.teamsync.testutil.TypicalAddressBook.JAN_MEETING;
+
+import org.junit.jupiter.api.Test;
+
+import syncsquad.teamsync.testutil.MeetingBuilder;
+
+public class MeetingTest {
+
+    @Test
+    public void equals() {
+        // same values -> returns true
+        Meeting janMeetingCopy = new MeetingBuilder(JAN_MEETING).build();
+        assertTrue(JAN_MEETING.equals(janMeetingCopy));
+
+        // same object -> returns true
+        assertTrue(JAN_MEETING.equals(JAN_MEETING));
+
+        // null -> returns false
+        assertFalse(JAN_MEETING.equals(null));
+
+        // different type -> returns false
+        assertFalse(JAN_MEETING.equals(5));
+
+        // different person -> returns false
+        assertFalse(JAN_MEETING.equals(FEB_MEETING));
+
+        // different date -> returns false
+        Meeting editedJanMeeting = new MeetingBuilder(JAN_MEETING).withDate(VALID_DATE_MAR_MEETING).build();
+        assertFalse(JAN_MEETING.equals(editedJanMeeting));
+
+        // different start time -> returns false
+        editedJanMeeting = new MeetingBuilder(JAN_MEETING).withStartTime(VALID_START_TIME_MAR_MEETING).build();
+        assertFalse(JAN_MEETING.equals(editedJanMeeting));
+
+        // different end time -> returns false
+        editedJanMeeting = new MeetingBuilder(JAN_MEETING).withEndTime(VALID_END_TIME_MAR_MEETING).build();
+        assertFalse(JAN_MEETING.equals(editedJanMeeting));
+    }
+
+    @Test
+    public void toStringMethod() {
+        String expected = JAN_MEETING.getDateString() + " from " + JAN_MEETING.getStartTimeString()
+                + " to " + JAN_MEETING.getEndTimeString();
+        assertEquals(expected, JAN_MEETING.toString());
+    }
+}

--- a/src/test/java/syncsquad/teamsync/model/meeting/MeetingTest.java
+++ b/src/test/java/syncsquad/teamsync/model/meeting/MeetingTest.java
@@ -48,8 +48,8 @@ public class MeetingTest {
 
     @Test
     public void toStringMethod() {
-        String expected = JAN_MEETING.getDateString() + " from " + JAN_MEETING.getStartTimeString()
-                + " to " + JAN_MEETING.getEndTimeString();
+        String expected = Meeting.class.getCanonicalName() + "{date=" +  JAN_MEETING.getDate()
+                + ", startTime=" + JAN_MEETING.getStartTime() + ", endTime=" + JAN_MEETING.getEndTime() + "}";
         assertEquals(expected, JAN_MEETING.toString());
     }
 }

--- a/src/test/java/syncsquad/teamsync/model/meeting/UniqueMeetingListTest.java
+++ b/src/test/java/syncsquad/teamsync/model/meeting/UniqueMeetingListTest.java
@@ -1,0 +1,113 @@
+package syncsquad.teamsync.model.meeting;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static syncsquad.teamsync.testutil.Assert.assertThrows;
+import static syncsquad.teamsync.testutil.TypicalAddressBook.FEB_MEETING;
+import static syncsquad.teamsync.testutil.TypicalAddressBook.JAN_MEETING;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import syncsquad.teamsync.model.meeting.exceptions.DuplicateMeetingException;
+import syncsquad.teamsync.model.meeting.exceptions.MeetingNotFoundException;
+
+public class UniqueMeetingListTest {
+
+    private final UniqueMeetingList uniqueMeetingList = new UniqueMeetingList();
+
+    @Test
+    public void contains_nullMeeting_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> uniqueMeetingList.contains(null));
+    }
+
+    @Test
+    public void contains_meetingNotInList_returnsFalse() {
+        assertFalse(uniqueMeetingList.contains(JAN_MEETING));
+    }
+
+    @Test
+    public void contains_meetingInList_returnsTrue() {
+        uniqueMeetingList.add(JAN_MEETING);
+        assertTrue(uniqueMeetingList.contains(JAN_MEETING));
+    }
+
+    @Test
+    public void add_nullMeeting_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> uniqueMeetingList.add(null));
+    }
+
+    @Test
+    public void add_duplicateMeeting_throwsDuplicateMeetingException() {
+        uniqueMeetingList.add(JAN_MEETING);
+        assertThrows(DuplicateMeetingException.class, () -> uniqueMeetingList.add(JAN_MEETING));
+    }
+
+    @Test
+    public void remove_nullMeeting_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> uniqueMeetingList.remove(null));
+    }
+
+    @Test
+    public void remove_meetingDoesNotExist_throwsMeetingNotFoundException() {
+        assertThrows(MeetingNotFoundException.class, () -> uniqueMeetingList.remove(JAN_MEETING));
+    }
+
+    @Test
+    public void remove_existingMeeting_removesMeeting() {
+        uniqueMeetingList.add(JAN_MEETING);
+        uniqueMeetingList.remove(JAN_MEETING);
+        UniqueMeetingList expectedUniqueMeetingList = new UniqueMeetingList();
+        assertEquals(expectedUniqueMeetingList, uniqueMeetingList);
+    }
+
+    @Test
+    public void setMeetings_nullUniqueMeetingList_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> uniqueMeetingList.setMeetings((UniqueMeetingList) null));
+    }
+
+    @Test
+    public void setMeetings_uniqueMeetingList_replacesOwnListWithProvidedUniqueMeetingList() {
+        uniqueMeetingList.add(JAN_MEETING);
+        UniqueMeetingList expectedUniqueMeetingList = new UniqueMeetingList();
+        expectedUniqueMeetingList.add(FEB_MEETING);
+        uniqueMeetingList.setMeetings(expectedUniqueMeetingList);
+        assertEquals(expectedUniqueMeetingList, uniqueMeetingList);
+    }
+
+    @Test
+    public void setMeetings_nullList_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> uniqueMeetingList.setMeetings((List<Meeting>) null));
+    }
+
+    @Test
+    public void setMeetings_list_replacesOwnListWithProvidedList() {
+        uniqueMeetingList.add(JAN_MEETING);
+        List<Meeting> meetingList = Collections.singletonList(FEB_MEETING);
+        uniqueMeetingList.setMeetings(meetingList);
+        UniqueMeetingList expectedUniqueMeetingList = new UniqueMeetingList();
+        expectedUniqueMeetingList.add(FEB_MEETING);
+        assertEquals(expectedUniqueMeetingList, uniqueMeetingList);
+    }
+
+    @Test
+    public void setMeetings_listWithDuplicateMeetings_throwsDuplicateMeetingException() {
+        List<Meeting> listWithDuplicateMeetings = Arrays.asList(JAN_MEETING, JAN_MEETING);
+        assertThrows(DuplicateMeetingException.class, () -> uniqueMeetingList.setMeetings(listWithDuplicateMeetings));
+    }
+
+    @Test
+    public void asUnmodifiableObservableList_modifyList_throwsUnsupportedOperationException() {
+        assertThrows(UnsupportedOperationException.class, ()
+                -> uniqueMeetingList.asUnmodifiableObservableList().remove(0));
+    }
+
+    @Test
+    public void toStringMethod() {
+        assertEquals(uniqueMeetingList.asUnmodifiableObservableList().toString(), uniqueMeetingList.toString());
+    }
+}

--- a/src/test/java/syncsquad/teamsync/storage/JsonAdaptedMeetingTest.java
+++ b/src/test/java/syncsquad/teamsync/storage/JsonAdaptedMeetingTest.java
@@ -1,0 +1,74 @@
+package syncsquad.teamsync.storage;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static syncsquad.teamsync.storage.JsonAdaptedMeeting.DATE_FIELD;
+import static syncsquad.teamsync.storage.JsonAdaptedMeeting.END_TIME_FIELD;
+import static syncsquad.teamsync.storage.JsonAdaptedMeeting.MISSING_FIELD_MESSAGE_FORMAT;
+import static syncsquad.teamsync.storage.JsonAdaptedMeeting.START_TIME_FIELD;
+import static syncsquad.teamsync.testutil.Assert.assertThrows;
+import static syncsquad.teamsync.testutil.TypicalAddressBook.FEB_MEETING;
+
+import org.junit.jupiter.api.Test;
+
+import syncsquad.teamsync.commons.exceptions.IllegalValueException;
+import syncsquad.teamsync.model.meeting.Meeting;
+
+public class JsonAdaptedMeetingTest {
+    private static final String INVALID_DATE = "later";
+    private static final String INVALID_START_TIME = "now";
+    private static final String INVALID_END_TIME = "3pm";
+
+
+    private static final String VALID_DATE = FEB_MEETING.getDateString();
+    private static final String VALID_START_TIME = FEB_MEETING.getStartTimeString();
+    private static final String VALID_END_TIME = FEB_MEETING.getEndTimeString();
+
+    @Test
+    public void toModelType_validMeetingDetails_returnsMeeting() throws Exception {
+        JsonAdaptedMeeting meeting = new JsonAdaptedMeeting(FEB_MEETING);
+        assertEquals(FEB_MEETING, meeting.toModelType());
+    }
+
+    @Test
+    public void toModelType_invalidDate_throwsIllegalValueException() {
+        JsonAdaptedMeeting meeting = new JsonAdaptedMeeting(INVALID_DATE, VALID_START_TIME, VALID_END_TIME);
+        String expectedMessage = Meeting.MESSAGE_CONSTRAINTS;
+        assertThrows(IllegalValueException.class, expectedMessage, meeting::toModelType);
+    }
+
+    @Test
+    public void toModelType_nullDate_throwsIllegalValueException() {
+        JsonAdaptedMeeting meeting = new JsonAdaptedMeeting(null, VALID_START_TIME, VALID_END_TIME);
+        String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, DATE_FIELD);
+        assertThrows(IllegalValueException.class, expectedMessage, meeting::toModelType);
+    }
+
+    @Test
+    public void toModelType_invalidStartTime_throwsIllegalValueException() {
+        JsonAdaptedMeeting meeting = new JsonAdaptedMeeting(VALID_DATE, INVALID_START_TIME, VALID_END_TIME);
+        String expectedMessage = Meeting.MESSAGE_CONSTRAINTS;
+        assertThrows(IllegalValueException.class, expectedMessage, meeting::toModelType);
+    }
+
+    @Test
+    public void toModelType_nullStartTime_throwsIllegalValueException() {
+        JsonAdaptedMeeting meeting = new JsonAdaptedMeeting(VALID_DATE, null, VALID_END_TIME);
+        String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, START_TIME_FIELD);
+        assertThrows(IllegalValueException.class, expectedMessage, meeting::toModelType);
+    }
+
+    @Test
+    public void toModelType_invalidEndTime_throwsIllegalValueException() {
+        JsonAdaptedMeeting meeting = new JsonAdaptedMeeting(VALID_DATE, VALID_START_TIME, INVALID_END_TIME);
+        String expectedMessage = Meeting.MESSAGE_CONSTRAINTS;
+        assertThrows(IllegalValueException.class, expectedMessage, meeting::toModelType);
+    }
+
+    @Test
+    public void toModelType_nullEndTime_throwsIllegalValueException() {
+        JsonAdaptedMeeting meeting = new JsonAdaptedMeeting(VALID_DATE, VALID_START_TIME, null);
+        String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, END_TIME_FIELD);
+        assertThrows(IllegalValueException.class, expectedMessage, meeting::toModelType);
+    }
+
+}

--- a/src/test/java/syncsquad/teamsync/storage/JsonAddressBookStorageTest.java
+++ b/src/test/java/syncsquad/teamsync/storage/JsonAddressBookStorageTest.java
@@ -4,8 +4,11 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static syncsquad.teamsync.testutil.Assert.assertThrows;
 import static syncsquad.teamsync.testutil.TypicalAddressBook.ALICE;
+import static syncsquad.teamsync.testutil.TypicalAddressBook.AUG_MEETING;
 import static syncsquad.teamsync.testutil.TypicalAddressBook.HOON;
 import static syncsquad.teamsync.testutil.TypicalAddressBook.IDA;
+import static syncsquad.teamsync.testutil.TypicalAddressBook.JAN_MEETING;
+import static syncsquad.teamsync.testutil.TypicalAddressBook.JUL_MEETING;
 import static syncsquad.teamsync.testutil.TypicalAddressBook.getTypicalAddressBook;
 
 import java.io.IOException;
@@ -61,6 +64,17 @@ public class JsonAddressBookStorageTest {
     }
 
     @Test
+    public void readAddressBook_invalidMeetingAddressBook_throwDataLoadingException() {
+        assertThrows(DataLoadingException.class, () -> readAddressBook("invalidMeetingAddressBook.json"));
+    }
+
+    @Test
+    public void readAddressBook_invalidAndValdiMeetingAddressBook_throwDataLoadingException() {
+        assertThrows(DataLoadingException.class, () -> readAddressBook("invalidAndValidMeetingAddressBook.json"));
+    }
+
+
+    @Test
     public void readAndSaveAddressBook_allInOrder_success() throws Exception {
         Path filePath = testFolder.resolve("TempAddressBook.json");
         AddressBook original = getTypicalAddressBook();
@@ -73,13 +87,16 @@ public class JsonAddressBookStorageTest {
 
         // Modify data, overwrite exiting file, and read back
         original.addPerson(HOON);
+        original.addMeeting(JUL_MEETING);
         original.removePerson(ALICE);
+        original.removeMeeting(JAN_MEETING);
         jsonAddressBookStorage.saveAddressBook(original, filePath);
         readBack = jsonAddressBookStorage.readAddressBook(filePath).get();
         assertEquals(original, new AddressBook(readBack));
 
         // Save and read without specifying file path
         original.addPerson(IDA);
+        original.addMeeting(AUG_MEETING);
         jsonAddressBookStorage.saveAddressBook(original); // file path not specified
         readBack = jsonAddressBookStorage.readAddressBook().get(); // file path not specified
         assertEquals(original, new AddressBook(readBack));

--- a/src/test/java/syncsquad/teamsync/storage/JsonSerializableAddressBookTest.java
+++ b/src/test/java/syncsquad/teamsync/storage/JsonSerializableAddressBookTest.java
@@ -22,6 +22,7 @@ public class JsonSerializableAddressBookTest {
     private static final Path TYPICAL_MEETINGS_FILE = TEST_DATA_FOLDER.resolve("typicalMeetingsAddressBook.json");
     private static final Path INVALID_MEETING_FILE = TEST_DATA_FOLDER.resolve("invalidMeetingAddressBook.json");
     private static final Path DUPLICATE_MEETING_FILE = TEST_DATA_FOLDER.resolve("duplicateMeetingAddressBook.json");
+    private static final Path OVERLAPPING_MEETING_FILE = TEST_DATA_FOLDER.resolve("overlappingMeetingAddressBook.json");
 
     @Test
     public void toModelType_typicalPersonsFile_success() throws Exception {
@@ -68,6 +69,14 @@ public class JsonSerializableAddressBookTest {
         JsonSerializableAddressBook dataFromFile = JsonUtil.readJsonFile(DUPLICATE_MEETING_FILE,
                 JsonSerializableAddressBook.class).get();
         assertThrows(IllegalValueException.class, JsonSerializableAddressBook.MESSAGE_DUPLICATE_MEETING,
+                dataFromFile::toModelType);
+    }
+
+    @Test
+    public void toModelType_overlappingMeetings_throwsIllegalValueException() throws Exception {
+        JsonSerializableAddressBook dataFromFile = JsonUtil.readJsonFile(OVERLAPPING_MEETING_FILE,
+                JsonSerializableAddressBook.class).get();
+        assertThrows(IllegalValueException.class, JsonSerializableAddressBook.MESSAGE_OVERLAPPING_MEETING,
                 dataFromFile::toModelType);
     }
 

--- a/src/test/java/syncsquad/teamsync/storage/JsonSerializableAddressBookTest.java
+++ b/src/test/java/syncsquad/teamsync/storage/JsonSerializableAddressBookTest.java
@@ -19,13 +19,16 @@ public class JsonSerializableAddressBookTest {
     private static final Path TYPICAL_PERSONS_FILE = TEST_DATA_FOLDER.resolve("typicalPersonsAddressBook.json");
     private static final Path INVALID_PERSON_FILE = TEST_DATA_FOLDER.resolve("invalidPersonAddressBook.json");
     private static final Path DUPLICATE_PERSON_FILE = TEST_DATA_FOLDER.resolve("duplicatePersonAddressBook.json");
+    private static final Path TYPICAL_MEETINGS_FILE = TEST_DATA_FOLDER.resolve("typicalMeetingsAddressBook.json");
+    private static final Path INVALID_MEETING_FILE = TEST_DATA_FOLDER.resolve("invalidMeetingAddressBook.json");
+    private static final Path DUPLICATE_MEETING_FILE = TEST_DATA_FOLDER.resolve("duplicateMeetingAddressBook.json");
 
     @Test
     public void toModelType_typicalPersonsFile_success() throws Exception {
         JsonSerializableAddressBook dataFromFile = JsonUtil.readJsonFile(TYPICAL_PERSONS_FILE,
                 JsonSerializableAddressBook.class).get();
         AddressBook addressBookFromFile = dataFromFile.toModelType();
-        AddressBook typicalPersonsAddressBook = TypicalAddressBook.getTypicalAddressBook();
+        AddressBook typicalPersonsAddressBook = TypicalAddressBook.getTypicalPersonsAddressBook();
         assertEquals(addressBookFromFile, typicalPersonsAddressBook);
     }
 
@@ -41,6 +44,30 @@ public class JsonSerializableAddressBookTest {
         JsonSerializableAddressBook dataFromFile = JsonUtil.readJsonFile(DUPLICATE_PERSON_FILE,
                 JsonSerializableAddressBook.class).get();
         assertThrows(IllegalValueException.class, JsonSerializableAddressBook.MESSAGE_DUPLICATE_PERSON,
+                dataFromFile::toModelType);
+    }
+
+    @Test
+    public void toModelType_typicalMeetingsFile_success() throws Exception {
+        JsonSerializableAddressBook dataFromFile = JsonUtil.readJsonFile(TYPICAL_MEETINGS_FILE,
+                JsonSerializableAddressBook.class).get();
+        AddressBook addressBookFromFile = dataFromFile.toModelType();
+        AddressBook typicalMeetingsAddressBook = TypicalAddressBook.getTypicalMeetingsAddressBook();
+        assertEquals(addressBookFromFile, typicalMeetingsAddressBook);
+    }
+
+    @Test
+    public void toModelType_invalidMeetingFile_throwsIllegalValueException() throws Exception {
+        JsonSerializableAddressBook dataFromFile = JsonUtil.readJsonFile(INVALID_MEETING_FILE,
+                JsonSerializableAddressBook.class).get();
+        assertThrows(IllegalValueException.class, dataFromFile::toModelType);
+    }
+
+    @Test
+    public void toModelType_duplicateMeetings_throwsIllegalValueException() throws Exception {
+        JsonSerializableAddressBook dataFromFile = JsonUtil.readJsonFile(DUPLICATE_MEETING_FILE,
+                JsonSerializableAddressBook.class).get();
+        assertThrows(IllegalValueException.class, JsonSerializableAddressBook.MESSAGE_DUPLICATE_MEETING,
                 dataFromFile::toModelType);
     }
 

--- a/src/test/java/syncsquad/teamsync/testutil/TypicalAddressBook.java
+++ b/src/test/java/syncsquad/teamsync/testutil/TypicalAddressBook.java
@@ -2,15 +2,15 @@ package syncsquad.teamsync.testutil;
 
 import static syncsquad.teamsync.logic.commands.CommandTestUtil.VALID_ADDRESS_AMY;
 import static syncsquad.teamsync.logic.commands.CommandTestUtil.VALID_ADDRESS_BOB;
-import static syncsquad.teamsync.logic.commands.CommandTestUtil.VALID_DATE_MAR_MEETING;
+import static syncsquad.teamsync.logic.commands.CommandTestUtil.VALID_DATE_SEP_MEETING;
 import static syncsquad.teamsync.logic.commands.CommandTestUtil.VALID_EMAIL_AMY;
 import static syncsquad.teamsync.logic.commands.CommandTestUtil.VALID_EMAIL_BOB;
-import static syncsquad.teamsync.logic.commands.CommandTestUtil.VALID_END_TIME_MAR_MEETING;
+import static syncsquad.teamsync.logic.commands.CommandTestUtil.VALID_END_TIME_SEP_MEETING;
 import static syncsquad.teamsync.logic.commands.CommandTestUtil.VALID_NAME_AMY;
 import static syncsquad.teamsync.logic.commands.CommandTestUtil.VALID_NAME_BOB;
 import static syncsquad.teamsync.logic.commands.CommandTestUtil.VALID_PHONE_AMY;
 import static syncsquad.teamsync.logic.commands.CommandTestUtil.VALID_PHONE_BOB;
-import static syncsquad.teamsync.logic.commands.CommandTestUtil.VALID_START_TIME_MAR_MEETING;
+import static syncsquad.teamsync.logic.commands.CommandTestUtil.VALID_START_TIME_SEP_MEETING;
 import static syncsquad.teamsync.logic.commands.CommandTestUtil.VALID_TAG_FRIEND;
 import static syncsquad.teamsync.logic.commands.CommandTestUtil.VALID_TAG_HUSBAND;
 
@@ -70,27 +70,38 @@ public class TypicalAddressBook {
             .withStartTime("3:00")
             .withEndTime("5:55")
             .build();
-    public static final Meeting JUN_MEETING = new MeetingBuilder().withDate("06-06-2025")
+    public static final Meeting MAR_MEETING = new MeetingBuilder().withDate("03-03-2025")
             .withStartTime("4:45")
             .withEndTime("10:59")
             .build();
-    public static final Meeting JUL_MEETING = new MeetingBuilder().withDate("07-07-2025")
+    public static final Meeting APR_MEETING = new MeetingBuilder().withDate("04-04-2025")
             .withStartTime("12:55")
             .withEndTime("16:00")
             .build();
-    public static final Meeting NOV_MEETING = new MeetingBuilder().withDate("11-11-2025")
+    public static final Meeting MAY_MEETING = new MeetingBuilder().withDate("05-05-2025")
             .withStartTime("18:00")
             .withEndTime("21:00")
             .build();
-    public static final Meeting DEC_MEETING = new MeetingBuilder().withDate("12-12-2025")
+    public static final Meeting JUN_MEETING = new MeetingBuilder().withDate("06-06-2025")
             .withStartTime("20:00")
             .withEndTime("23:59")
             .build();
 
+    // Manually added
+    public static final Meeting JUL_MEETING = new MeetingBuilder().withDate("07-07-2025")
+            .withStartTime("10:40")
+            .withEndTime("12:45")
+            .build();
+
+    public static final Meeting AUG_MEETING = new MeetingBuilder().withDate("08-08-2025")
+            .withStartTime("15:00")
+            .withEndTime("18:30")
+            .build();
+
     // Manually added - Meeting's details found in {@code CommandTestUtil}
-    public static final Meeting MAR_MEETING = new MeetingBuilder().withDate(VALID_DATE_MAR_MEETING)
-            .withStartTime(VALID_START_TIME_MAR_MEETING)
-            .withEndTime(VALID_END_TIME_MAR_MEETING).build();
+    public static final Meeting SEP_MEETING = new MeetingBuilder().withDate(VALID_DATE_SEP_MEETING)
+            .withStartTime(VALID_START_TIME_SEP_MEETING)
+            .withEndTime(VALID_END_TIME_SEP_MEETING).build();
 
     private TypicalAddressBook() {} // prevents instantiation
 
@@ -113,7 +124,7 @@ public class TypicalAddressBook {
     }
 
     public static List<Meeting> getTypicalMeetings() {
-        return new ArrayList<>(Arrays.asList(JAN_MEETING, FEB_MEETING, JUN_MEETING, JUL_MEETING,
-                NOV_MEETING, DEC_MEETING));
+        return new ArrayList<>(Arrays.asList(JAN_MEETING, FEB_MEETING, MAR_MEETING, APR_MEETING,
+                MAY_MEETING, JUN_MEETING));
     }
 }

--- a/src/test/java/syncsquad/teamsync/testutil/TypicalAddressBook.java
+++ b/src/test/java/syncsquad/teamsync/testutil/TypicalAddressBook.java
@@ -106,13 +106,35 @@ public class TypicalAddressBook {
     private TypicalAddressBook() {} // prevents instantiation
 
     /**
-     * Returns an {@code AddressBook} with all the typical persons.
+     * Returns an {@code AddressBook} with all the typical persons and meetings.
      */
     public static AddressBook getTypicalAddressBook() {
         AddressBook ab = new AddressBook();
         for (Person person : getTypicalPersons()) {
             ab.addPerson(person);
         }
+        for (Meeting meeting : getTypicalMeetings()) {
+            ab.addMeeting(meeting);
+        }
+        return ab;
+    }
+
+    /**
+     * Returns an {@code AddressBook} with all the typical persons.
+     */
+    public static AddressBook getTypicalPersonsAddressBook() {
+        AddressBook ab = new AddressBook();
+        for (Person person : getTypicalPersons()) {
+            ab.addPerson(person);
+        }
+        return ab;
+    }
+
+    /**
+     * Returns an {@code AddressBook} with all the typical meetings.
+     */
+    public static AddressBook getTypicalMeetingsAddressBook() {
+        AddressBook ab = new AddressBook();
         for (Meeting meeting : getTypicalMeetings()) {
             ab.addMeeting(meeting);
         }


### PR DESCRIPTION
Fixes #124

Add tests for:
- [X] Meeting
- [X] UniqueMeetingList
- [X] JsonAdaptedMeetingList
- [X] JsonAddressBookStorage
- [X] JsonSerializableAddressBook

Also note the following changes:
* Separate the internal string representation of a Meeting object and the details displayed to the user
  * Update toString method in Meeting to return the internal representation
  * Add format(Meeting) method in Messages to return the details to be displayed to the user
* Update toModelType method in JsonAdaptedMeeting to throw an exception that specifies which field is missing, if applicable
* Update TypicalAddressBook
  * Added more sample Meeting objects for tests
  * Update the Meeting objects to span sequential months for easier use
  * Add two methods, getTypicalMeetingsAddressBook and getTypicalPersons, which returns an AddressBook containing only the typical meetings and persons respectively
* Update equals method of AddressBook to compare both persons and meetings
* Add hasOverlappingMeeting and hasOverlap method to AddressBook and UniqueMeetingList respectively

Proposed commit message:
```
Add tests for meeting handling in Model and Storage components

Tests for the Model and Storage components are not updated for the
addition of meetings

Let's add tests for:
* Meeting
* UniqueMeetingList
* JsonAdaptedMeetingList
* JsonAddressBookStorage
* JsonSerializableAddressBook

Let's also:
* Separate the internal string representation of a Meeting object and
  the details displayed to the user
  * Update toString method in Meeting to return the internal
    representation
  * Add format(Meeting) method in Messages to return the details to be
    displayed to the user
* Update toModelType method in JsonAdaptedMeeting to throw an exception
  that specifies which field is missing, if applicable
* Update TypicalAddressBook
  * Add more sample Meeting objects for tests
  * Update the Meeting objects to span sequential months for easier use
  * Add two methods, getTypicalMeetingsAddressBook and
    getTypicalPersons, which returns an AddressBook containing only the
    typical meetings and persons respectively
* Update equals method of AddressBook to compare both persons and
  meetings
* Add hasOverlappingMeeting and hasOverlap method to AddressBook and
  UniqueMeetingList respectively to check for overlapping meetings
```