### PR TITLE
Meetings displayed by listmeetings are not formatted properly #131

### DIFF
--- a/src/main/java/syncsquad/teamsync/logic/commands/ListMeetingsCommand.java
+++ b/src/main/java/syncsquad/teamsync/logic/commands/ListMeetingsCommand.java
@@ -3,7 +3,6 @@ package syncsquad.teamsync.logic.commands;
 import static java.util.Objects.requireNonNull;
 
 import syncsquad.teamsync.model.Model;
-import syncsquad.teamsync.model.meeting.Meeting;
 
 /**
  * Lists all meetings in the address book to the user.

--- a/src/main/java/syncsquad/teamsync/logic/commands/ListMeetingsCommand.java
+++ b/src/main/java/syncsquad/teamsync/logic/commands/ListMeetingsCommand.java
@@ -2,6 +2,7 @@ package syncsquad.teamsync.logic.commands;
 
 import static java.util.Objects.requireNonNull;
 
+import syncsquad.teamsync.commons.util.ToStringBuilder;
 import syncsquad.teamsync.model.Model;
 
 /**
@@ -18,5 +19,21 @@ public class ListMeetingsCommand extends Command {
         requireNonNull(model);
         String meetingsDisplay = String.join("\n", MESSAGE_SUCCESS, model.displayMeetingsString());
         return new CommandResult(meetingsDisplay);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        // short circuit if same object
+        if (other == this) {
+            return true;
+        }
+
+        // returns true if other is a ListMeetingsCommand object
+        return other instanceof ListMeetingsCommand;
+    }
+
+    @Override
+    public String toString() {
+        return new ToStringBuilder(this).toString();
     }
 }

--- a/src/main/java/syncsquad/teamsync/logic/commands/ListMeetingsCommand.java
+++ b/src/main/java/syncsquad/teamsync/logic/commands/ListMeetingsCommand.java
@@ -17,10 +17,7 @@ public class ListMeetingsCommand extends Command {
     @Override
     public CommandResult execute(Model model) {
         requireNonNull(model);
-        String meetings = "";
-        for (Meeting item : model.getMeetingList()) {
-            meetings += item.toString() + "\n";
-        }
-        return new CommandResult(MESSAGE_SUCCESS + "\n" + meetings);
+        String meetingsDisplay = String.join("\n", MESSAGE_SUCCESS, model.displayMeetingsString());
+        return new CommandResult(meetingsDisplay);
     }
 }

--- a/src/main/java/syncsquad/teamsync/model/AddressBook.java
+++ b/src/main/java/syncsquad/teamsync/model/AddressBook.java
@@ -143,6 +143,12 @@ public class AddressBook implements ReadOnlyAddressBook {
         meetings.remove(key);
     }
 
+    /**
+     * Returns the meetings list as a string formatted for display to the user
+     */
+    public String displayMeetingsString() {
+        return meetings.toDisplayString();
+    }
     //// util methods
 
     @Override

--- a/src/main/java/syncsquad/teamsync/model/Model.java
+++ b/src/main/java/syncsquad/teamsync/model/Model.java
@@ -104,6 +104,12 @@ public interface Model {
      */
     void deleteMeeting(Meeting meeting);
 
+    /**
+     * Returns the meetings list as a string formatted for display to the user
+     */
+    String displayMeetingsString();
+
+
     /** Returns an unmodifiable view of the list of meetings */
     ObservableList<Meeting> getMeetingList();
 }

--- a/src/main/java/syncsquad/teamsync/model/ModelManager.java
+++ b/src/main/java/syncsquad/teamsync/model/ModelManager.java
@@ -131,6 +131,11 @@ public class ModelManager implements Model {
     }
 
     @Override
+    public String displayMeetingsString() {
+        return addressBook.displayMeetingsString();
+    }
+
+    @Override
     public ObservableList<Meeting> getMeetingList() {
         return meetings;
     }

--- a/src/main/java/syncsquad/teamsync/model/meeting/UniqueMeetingList.java
+++ b/src/main/java/syncsquad/teamsync/model/meeting/UniqueMeetingList.java
@@ -5,9 +5,13 @@ import static syncsquad.teamsync.commons.util.CollectionUtil.requireAllNonNull;
 
 import java.util.Iterator;
 import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
 
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
+import syncsquad.teamsync.logic.Messages;
 import syncsquad.teamsync.model.meeting.exceptions.DuplicateMeetingException;
 import syncsquad.teamsync.model.meeting.exceptions.MeetingNotFoundException;
 
@@ -108,6 +112,24 @@ public class UniqueMeetingList implements Iterable<Meeting> {
 
         UniqueMeetingList otherUniqueMeetingList = (UniqueMeetingList) other;
         return internalList.equals(otherUniqueMeetingList.internalList);
+    }
+
+    /**
+     * Returns the meetings list as a string formatted for display to the user
+     */
+    public String toDisplayString() {
+        // Iterator which contains the indices formatted for display to the user
+        Iterator<String> indicesIterator = IntStream.range(1, internalList.size() + 1)
+                .mapToObj(i -> i + ". ")
+                .iterator();
+        // Iterator which contains the meetings formatted for display to the user
+        Iterator<String> meetingsIterator = internalList.stream()
+                .map(Messages::format)
+                .iterator();
+
+        return IntStream.range(0, internalList.size())
+                .mapToObj(i -> indicesIterator.next() + meetingsIterator.next())
+                .collect(Collectors.joining("\n"));
     }
 
     @Override

--- a/src/main/java/syncsquad/teamsync/model/meeting/UniqueMeetingList.java
+++ b/src/main/java/syncsquad/teamsync/model/meeting/UniqueMeetingList.java
@@ -7,7 +7,6 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
-import java.util.stream.Stream;
 
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;

--- a/src/test/java/syncsquad/teamsync/logic/commands/AddMeetingCommandTest.java
+++ b/src/test/java/syncsquad/teamsync/logic/commands/AddMeetingCommandTest.java
@@ -176,6 +176,10 @@ public class AddMeetingCommandTest {
             throw new AssertionError("This method should not be called.");
         }
 
+        public String displayMeetingsString() {
+            throw new AssertionError("This method should not be called.");
+        }
+
         @Override
         public ObservableList<Meeting> getMeetingList() {
             throw new AssertionError("This method should not be called.");

--- a/src/test/java/syncsquad/teamsync/logic/commands/AddPersonCommandTest.java
+++ b/src/test/java/syncsquad/teamsync/logic/commands/AddPersonCommandTest.java
@@ -175,6 +175,10 @@ public class AddPersonCommandTest {
             throw new AssertionError("This method should not be called.");
         }
 
+        public String displayMeetingsString() {
+            throw new AssertionError("This method should not be called.");
+        }
+
         @Override
         public ObservableList<Meeting> getMeetingList() {
             throw new AssertionError("This method should not be called.");

--- a/src/test/java/syncsquad/teamsync/logic/commands/ListMeetingsCommandTest.java
+++ b/src/test/java/syncsquad/teamsync/logic/commands/ListMeetingsCommandTest.java
@@ -1,40 +1,175 @@
+
 package syncsquad.teamsync.logic.commands;
 
-import static syncsquad.teamsync.logic.commands.CommandTestUtil.assertCommandSuccess;
-import static syncsquad.teamsync.testutil.TypicalAddressBook.getTypicalAddressBook;
-import static syncsquad.teamsync.testutil.TypicalAddressBook.getTypicalMeetings;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static syncsquad.teamsync.logic.commands.CommandTestUtil.DATE_DESC_SEP_MEETING;
+import static syncsquad.teamsync.logic.commands.CommandTestUtil.END_TIME_DESC_SEP_MEETING;
+import static syncsquad.teamsync.logic.commands.CommandTestUtil.START_TIME_DESC_SEP_MEETING;
 
-import java.util.stream.Collectors;
+import java.nio.file.Path;
+import java.util.function.Predicate;
 
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import javafx.collections.ObservableList;
+import syncsquad.teamsync.commons.core.GuiSettings;
 import syncsquad.teamsync.model.Model;
-import syncsquad.teamsync.model.ModelManager;
-import syncsquad.teamsync.model.UserPrefs;
+import syncsquad.teamsync.model.ReadOnlyAddressBook;
+import syncsquad.teamsync.model.ReadOnlyUserPrefs;
 import syncsquad.teamsync.model.meeting.Meeting;
+import syncsquad.teamsync.model.person.Person;
 
-/**
- * Contains integration tests (interaction with the Model) and unit tests for ListCommand.
- */
 public class ListMeetingsCommandTest {
 
-    private static final String EXPECTED_MESSAGE = ListMeetingsCommand.MESSAGE_SUCCESS + "\n"
-            + getTypicalMeetings()
-            .stream()
-            .map(Meeting::toString)
-            .collect(Collectors.joining("\n")) + "\n";
-    private Model model;
-    private Model expectedModel;
+    private static final String MEETING_DISPLAY = "1." + DATE_DESC_SEP_MEETING + "; Start time:"
+            + START_TIME_DESC_SEP_MEETING + "; End time:" + END_TIME_DESC_SEP_MEETING;
 
-    @BeforeEach
-    public void setUp() {
-        model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
-        expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
+    @Test
+    public void execute_displaysMeetings_listMeetingsSuccessful() {
+        ModelStubAcceptingDisplayMeetings modelStub = new ModelStubAcceptingDisplayMeetings();
+
+        CommandResult commandResult = new ListMeetingsCommand().execute(modelStub);
+
+        assertEquals(String.join("\n", ListMeetingsCommand.MESSAGE_SUCCESS, MEETING_DISPLAY),
+                commandResult.getFeedbackToUser());
     }
 
     @Test
-    public void execute_showsAllMeetings() {
-        assertCommandSuccess(new ListMeetingsCommand(), model, EXPECTED_MESSAGE, model);
+    public void equals() {
+        ListMeetingsCommand listMeetingsCommand = new ListMeetingsCommand();
+        ListMeetingsCommand otherListMeetingsCommand = new ListMeetingsCommand();
+
+        // same object -> returns true
+        assertTrue(listMeetingsCommand.equals(listMeetingsCommand));
+
+        // both objects are instances of ListMeetingsCommand -> returns true
+        assertTrue(listMeetingsCommand.equals(otherListMeetingsCommand));
+
+        // different types -> returns false
+        assertFalse(listMeetingsCommand.equals(1));
+
+        // null -> returns false
+        assertFalse(listMeetingsCommand.equals(null));
     }
+
+    @Test
+    public void toStringMethod() {
+        ListMeetingsCommand listMeetingsCommand = new ListMeetingsCommand();
+        String expected = ListMeetingsCommand.class.getCanonicalName() + "{}";
+        assertEquals(expected, listMeetingsCommand.toString());
+    }
+
+    /**
+     * A default model stub that have all of the methods failing.
+     */
+    private class ModelStub implements Model {
+        @Override
+        public void setUserPrefs(ReadOnlyUserPrefs userPrefs) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public ReadOnlyUserPrefs getUserPrefs() {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public GuiSettings getGuiSettings() {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void setGuiSettings(GuiSettings guiSettings) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public Path getAddressBookFilePath() {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void setAddressBookFilePath(Path addressBookFilePath) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void addPerson(Person person) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void setAddressBook(ReadOnlyAddressBook newData) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public ReadOnlyAddressBook getAddressBook() {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public boolean hasPerson(Person person) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void deletePerson(Person target) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void setPerson(Person target, Person editedPerson) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public ObservableList<Person> getFilteredPersonList() {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void updateFilteredPersonList(Predicate<Person> predicate) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public boolean hasMeeting(Meeting meeting) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void addMeeting(Meeting meeting) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void deleteMeeting(Meeting meeting) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        public String displayMeetingsString() {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public ObservableList<Meeting> getMeetingList() {
+            throw new AssertionError("This method should not be called.");
+        }
+
+    }
+
+    /**
+     * A Model stub that always accepts displaying meetings
+     */
+    private class ModelStubAcceptingDisplayMeetings extends ModelStub {
+
+        @Override
+        public String displayMeetingsString() {
+            return MEETING_DISPLAY;
+        }
+    }
+
 }


### PR DESCRIPTION
Fixes #131, fixes #137

Listmeetings displays the internal string representation of the Meetings. Additionally, ListMeetingsCommand does not override the equals and toString methods.

Let's
* format the displayed Meetings for user display and add the corresponding indices.
* override the equals and toString methods in ListMeetingsCommand
* add tests for ListMeetingsCommand

Before:
![image](https://github.com/user-attachments/assets/e55f35ab-ca36-4072-a694-ec3bb0ed0a28)

After:
![image](https://github.com/user-attachments/assets/b48f5c97-2f7a-423d-842a-51dfc5a99b83)

Proposed commit message:
```
Fix formatting issues in the meetings displayed by listmeetings

Listmeetings displays the internal string representation of the
Meetings. Additionally, ListMeetingsCommand does not override the equals
and toString methods.

Let's 
* format the displayed Meetings for user display and add the
  corresponding indices.
* override the equals and toString methods in ListMeetingsCommand
* add tests for ListMeetingsCommand
```