### PR TITLE
Extract common operations in UniqueMeetingList and UniquePersonList #140

### DIFF
--- a/src/main/java/syncsquad/teamsync/commons/exceptions/DuplicateItemException.java
+++ b/src/main/java/syncsquad/teamsync/commons/exceptions/DuplicateItemException.java
@@ -1,9 +1,12 @@
 package syncsquad.teamsync.commons.exceptions;
 
+/**
+ * Signals that an operation will result in duplicate items.
+ */
 public class DuplicateItemException extends RuntimeException {
 
     public DuplicateItemException() {
-
+        super("Operation would result in duplicate items");
     }
 
     public DuplicateItemException(String message) {

--- a/src/main/java/syncsquad/teamsync/commons/exceptions/DuplicateItemException.java
+++ b/src/main/java/syncsquad/teamsync/commons/exceptions/DuplicateItemException.java
@@ -1,0 +1,12 @@
+package syncsquad.teamsync.commons.exceptions;
+
+public class DuplicateItemException extends RuntimeException {
+
+    public DuplicateItemException() {
+
+    }
+
+    public DuplicateItemException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/syncsquad/teamsync/commons/exceptions/ItemNotFoundException.java
+++ b/src/main/java/syncsquad/teamsync/commons/exceptions/ItemNotFoundException.java
@@ -1,0 +1,12 @@
+package syncsquad.teamsync.commons.exceptions;
+
+public class ItemNotFoundException extends RuntimeException {
+
+    public ItemNotFoundException() {
+
+    }
+
+    public ItemNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/syncsquad/teamsync/commons/exceptions/ItemNotFoundException.java
+++ b/src/main/java/syncsquad/teamsync/commons/exceptions/ItemNotFoundException.java
@@ -1,12 +1,6 @@
 package syncsquad.teamsync.commons.exceptions;
 
-public class ItemNotFoundException extends RuntimeException {
-
-    public ItemNotFoundException() {
-
-    }
-
-    public ItemNotFoundException(String message) {
-        super(message);
-    }
-}
+/**
+ * Signals that an operation is unable to find the specified item.
+ */
+public class ItemNotFoundException extends RuntimeException {}

--- a/src/main/java/syncsquad/teamsync/model/AddressBook.java
+++ b/src/main/java/syncsquad/teamsync/model/AddressBook.java
@@ -49,7 +49,7 @@ public class AddressBook implements ReadOnlyAddressBook {
      * {@code persons} must not contain duplicate persons.
      */
     public void setPersons(List<Person> persons) {
-        this.persons.setPersons(persons);
+        this.persons.setItems(persons);
     }
 
     /**
@@ -57,7 +57,7 @@ public class AddressBook implements ReadOnlyAddressBook {
      * {@code meetings} must not contain duplicate meetings.
      */
     public void setMeetings(List<Meeting> meetings) {
-        this.meetings.setMeetings(meetings);
+        this.meetings.setItems(meetings);
     }
 
     /**
@@ -96,7 +96,7 @@ public class AddressBook implements ReadOnlyAddressBook {
     public void setPerson(Person target, Person editedPerson) {
         requireNonNull(editedPerson);
 
-        persons.setPerson(target, editedPerson);
+        persons.setItem(target, editedPerson);
     }
 
     /**

--- a/src/main/java/syncsquad/teamsync/model/UniqueItemList.java
+++ b/src/main/java/syncsquad/teamsync/model/UniqueItemList.java
@@ -1,0 +1,174 @@
+package syncsquad.teamsync.model;
+
+import static java.util.Objects.requireNonNull;
+import static syncsquad.teamsync.commons.util.CollectionUtil.requireAllNonNull;
+
+import java.util.Iterator;
+import java.util.List;
+
+import javafx.collections.FXCollections;
+import javafx.collections.ObservableList;
+import syncsquad.teamsync.commons.exceptions.DuplicateItemException;
+import syncsquad.teamsync.commons.exceptions.ItemNotFoundException;
+
+/**
+ * A list of items that enforces uniqueness between its elements and does not allow nulls.
+ * An item is considered unique by comparing using {@code isSameItem(T, T)}. As such, adding and updating of
+ * items uses isSameItem(T, T) for equality so as to ensure that the item being added or updated is
+ * unique in terms of identity in the UniqueList. However, the removal of an item uses T#equals(Object) so
+ * as to ensure that the item with exactly the same details will be removed.
+ *
+ * Supports a minimal set of list operations.
+ *
+ * @see UniqueItemList#isSameItem(T, T)
+ */
+public abstract class UniqueItemList<T> implements Iterable<T> {
+
+    protected final ObservableList<T> internalList = FXCollections.observableArrayList();
+    protected final ObservableList<T> internalUnmodifiableList =
+            FXCollections.unmodifiableObservableList(internalList);
+
+    /**
+     * Returns true if the list contains an equivalent item as the given argument.
+     */
+    public boolean contains(T toCheck) {
+        requireNonNull(toCheck);
+        return internalList.stream().anyMatch(item -> isSameItem(toCheck, item));
+    }
+
+    /**
+     * Adds an item to the list.
+     * The item must not already exist in the list.
+     */
+    public void add(T toAdd) {
+        requireNonNull(toAdd);
+        if (contains(toAdd)) {
+            throw duplicateItemException();
+        }
+        internalList.add(toAdd);
+    }
+
+    /**
+     * Replaces the item {@code target} in the list with {@code editedItem}.
+     * {@code item} must exist in the list.
+     * The item identity of {@code editedItem} must not be the same as another existing item in the list.
+     */
+    public void setItem(T target, T editedItem) {
+        requireAllNonNull(target, editedItem);
+
+        int index = internalList.indexOf(target);
+        if (index == -1) {
+            throw itemNotFoundException();
+        }
+
+        if (!isSameItem(target, editedItem) && contains(editedItem)) {
+            throw duplicateItemException();
+        }
+
+        internalList.set(index, editedItem);
+    }
+
+    /**
+     * Removes the equivalent item from the list.
+     * The item must exist in the list.
+     */
+    public void remove(T toRemove) {
+        requireNonNull(toRemove);
+        if (!internalList.remove(toRemove)) {
+            throw itemNotFoundException();
+        }
+    }
+
+    public void setItems(UniqueItemList<T> replacement) {
+        requireNonNull(replacement);
+        internalList.setAll(replacement.internalList);
+    }
+
+    /**
+     * Replaces the contents of this list with {@code items}.
+     * {@code items} must not contain duplicate items.
+     */
+    public void setItems(List<T> items) {
+        requireAllNonNull(items);
+        if (!itemsAreUnique(items)) {
+            throw duplicateItemException();
+        }
+
+        internalList.setAll(items);
+    }
+
+    /**
+     * Returns the backing list as an unmodifiable {@code ObservableList}.
+     */
+    public ObservableList<T> asUnmodifiableObservableList() {
+        return internalUnmodifiableList;
+    }
+
+    @Override
+    public Iterator<T> iterator() {
+        return internalList.iterator();
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof UniqueItemList<?>)) {
+            return false;
+        }
+
+        UniqueItemList<?> otherUniqueItemList = (UniqueItemList<?>) other;
+        return internalList.equals(otherUniqueItemList.internalList);
+    }
+
+    @Override
+    public int hashCode() {
+        return internalList.hashCode();
+    }
+
+    @Override
+    public String toString() {
+        return internalList.toString();
+    }
+
+    /**
+     * Returns true if {@code items} contains only unique items.
+     */
+    private boolean itemsAreUnique(List<T> items) {
+        for (int i = 0; i < items.size() - 1; i++) {
+            for (int j = i + 1; j < items.size(); j++) {
+                if (isSameItem(items.get(i), (items.get(j)))) {
+                    return false;
+                }
+            }
+        }
+        return true;
+    }
+
+    /**
+     * Defines a notion of equality for two items in the UniqueList.
+     * This methodd can be overridden to define a weaker or stronger notion of equality.
+     */
+    protected boolean isSameItem(T item1, T item2) {
+        return item1.equals(item2);
+    };
+
+    /**
+     * Returns a generic DuplicateItemException.
+     * This method can be overridden to return a custom exception.
+     */
+    protected DuplicateItemException duplicateItemException() {
+        throw new DuplicateItemException();
+    }
+
+    /**
+     * Returns a generic ItemNotFoundException.
+     * This method can be overridden to return a custom exception.
+     */
+    protected ItemNotFoundException itemNotFoundException() {
+        throw new ItemNotFoundException();
+    }
+}

--- a/src/main/java/syncsquad/teamsync/model/meeting/UniqueMeetingList.java
+++ b/src/main/java/syncsquad/teamsync/model/meeting/UniqueMeetingList.java
@@ -1,16 +1,15 @@
 package syncsquad.teamsync.model.meeting;
 
 import static java.util.Objects.requireNonNull;
-import static syncsquad.teamsync.commons.util.CollectionUtil.requireAllNonNull;
 
 import java.util.Iterator;
-import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
-import javafx.collections.FXCollections;
-import javafx.collections.ObservableList;
+import syncsquad.teamsync.commons.exceptions.DuplicateItemException;
+import syncsquad.teamsync.commons.exceptions.ItemNotFoundException;
 import syncsquad.teamsync.logic.Messages;
+import syncsquad.teamsync.model.UniqueItemList;
 import syncsquad.teamsync.model.meeting.exceptions.DuplicateMeetingException;
 import syncsquad.teamsync.model.meeting.exceptions.MeetingNotFoundException;
 
@@ -23,19 +22,7 @@ import syncsquad.teamsync.model.meeting.exceptions.MeetingNotFoundException;
  *
  * @see Meeting#equals(Object)
  */
-public class UniqueMeetingList implements Iterable<Meeting> {
-
-    private final ObservableList<Meeting> internalList = FXCollections.observableArrayList();
-    private final ObservableList<Meeting> internalUnmodifiableList =
-            FXCollections.unmodifiableObservableList(internalList);
-
-    /**
-     * Returns true if the list contains an equivalent meeting as the given argument.
-     */
-    public boolean contains(Meeting toCheck) {
-        requireNonNull(toCheck);
-        return internalList.stream().anyMatch(toCheck::equals);
-    }
+public class UniqueMeetingList extends UniqueItemList<Meeting> {
 
     /**
      * Returns true if the list contains a meeting that overlaps with the given argument.
@@ -43,74 +30,6 @@ public class UniqueMeetingList implements Iterable<Meeting> {
     public boolean hasOverlap(Meeting toCheck) {
         requireNonNull(toCheck);
         return internalList.stream().anyMatch(toCheck::isOverlapping);
-    }
-
-    /**
-     * Adds a meeting to the list.
-     * The meeting must not already exist in the list.
-     */
-    public void add(Meeting toAdd) {
-        requireNonNull(toAdd);
-        if (contains(toAdd)) {
-            throw new DuplicateMeetingException();
-        }
-        internalList.add(toAdd);
-    }
-
-    /**
-     * Removes the equivalent person from the list.
-     * The person must exist in the list.
-     */
-    public void remove(Meeting toRemove) {
-        requireNonNull(toRemove);
-        if (!internalList.remove(toRemove)) {
-            throw new MeetingNotFoundException();
-        }
-    }
-
-    public void setMeetings(UniqueMeetingList replacement) {
-        requireNonNull(replacement);
-        internalList.setAll(replacement.internalList);
-    }
-
-    /**
-     * Replaces the contents of this list with {@code meetings}.
-     * {@code meetings} must not contain duplicate meetings.
-     */
-    public void setMeetings(List<Meeting> meetings) {
-        requireAllNonNull(meetings);
-        if (!meetingsAreUnique(meetings)) {
-            throw new DuplicateMeetingException();
-        }
-
-        internalList.setAll(meetings);
-    }
-
-    /**
-     * Returns the backing list as an unmodifiable {@code ObservableList}.
-     */
-    public ObservableList<Meeting> asUnmodifiableObservableList() {
-        return internalUnmodifiableList;
-    }
-
-    @Override
-    public Iterator<Meeting> iterator() {
-        return internalList.iterator();
-    }
-
-    @Override
-    public boolean equals(Object other) {
-        if (other == this) {
-            return true;
-        }
-
-        // instanceof handles nulls
-        if (!(other instanceof UniqueMeetingList)) {
-            return false;
-        }
-
-        UniqueMeetingList otherUniqueMeetingList = (UniqueMeetingList) other;
-        return internalList.equals(otherUniqueMeetingList.internalList);
     }
 
     /**
@@ -132,27 +51,12 @@ public class UniqueMeetingList implements Iterable<Meeting> {
     }
 
     @Override
-    public int hashCode() {
-        return internalList.hashCode();
+    protected DuplicateItemException duplicateItemException() {
+        throw new DuplicateMeetingException();
     }
 
     @Override
-    public String toString() {
-        return internalList.toString();
+    protected ItemNotFoundException itemNotFoundException() {
+        throw new MeetingNotFoundException();
     }
-
-    /**
-     * Returns true if {@code meetings} contains only unique meetings.
-     */
-    private boolean meetingsAreUnique(List<Meeting> meetings) {
-        for (int i = 0; i < meetings.size() - 1; i++) {
-            for (int j = i + 1; j < meetings.size(); j++) {
-                if (meetings.get(i).equals(meetings.get(j))) {
-                    return false;
-                }
-            }
-        }
-        return true;
-    }
-
 }

--- a/src/main/java/syncsquad/teamsync/model/meeting/exceptions/DuplicateMeetingException.java
+++ b/src/main/java/syncsquad/teamsync/model/meeting/exceptions/DuplicateMeetingException.java
@@ -1,10 +1,12 @@
 package syncsquad.teamsync.model.meeting.exceptions;
 
+import syncsquad.teamsync.commons.exceptions.DuplicateItemException;
+
 /**
  * Signals that the operation will result in duplicate Meetings (Meetings are considered duplicates if they have the
  * same date, start time and end time).
  */
-public class DuplicateMeetingException extends RuntimeException {
+public class DuplicateMeetingException extends DuplicateItemException {
     public DuplicateMeetingException() {
         super("Operation would result in duplicate meetings");
     }

--- a/src/main/java/syncsquad/teamsync/model/meeting/exceptions/MeetingNotFoundException.java
+++ b/src/main/java/syncsquad/teamsync/model/meeting/exceptions/MeetingNotFoundException.java
@@ -1,6 +1,8 @@
 package syncsquad.teamsync.model.meeting.exceptions;
 
+import syncsquad.teamsync.commons.exceptions.ItemNotFoundException;
+
 /**
  * Signals that the operation is unable to find the specified meeting.
  */
-public class MeetingNotFoundException extends RuntimeException {}
+public class MeetingNotFoundException extends ItemNotFoundException {}

--- a/src/main/java/syncsquad/teamsync/model/person/UniquePersonList.java
+++ b/src/main/java/syncsquad/teamsync/model/person/UniquePersonList.java
@@ -3,11 +3,9 @@ package syncsquad.teamsync.model.person;
 import static java.util.Objects.requireNonNull;
 import static syncsquad.teamsync.commons.util.CollectionUtil.requireAllNonNull;
 
-import java.util.Iterator;
-import java.util.List;
-
-import javafx.collections.FXCollections;
-import javafx.collections.ObservableList;
+import syncsquad.teamsync.commons.exceptions.DuplicateItemException;
+import syncsquad.teamsync.commons.exceptions.ItemNotFoundException;
+import syncsquad.teamsync.model.UniqueItemList;
 import syncsquad.teamsync.model.person.exceptions.DuplicatePersonException;
 import syncsquad.teamsync.model.person.exceptions.PersonNotFoundException;
 
@@ -22,129 +20,24 @@ import syncsquad.teamsync.model.person.exceptions.PersonNotFoundException;
  *
  * @see Person#isSamePerson(Person)
  */
-public class UniquePersonList implements Iterable<Person> {
-
-    private final ObservableList<Person> internalList = FXCollections.observableArrayList();
-    private final ObservableList<Person> internalUnmodifiableList =
-            FXCollections.unmodifiableObservableList(internalList);
+public class UniquePersonList extends UniqueItemList<Person> {
 
     /**
-     * Returns true if the list contains an equivalent person as the given argument.
+     * Use a Person specific notion of equality to enforce uniqueness
      */
-    public boolean contains(Person toCheck) {
-        requireNonNull(toCheck);
-        return internalList.stream().anyMatch(toCheck::isSamePerson);
-    }
-
-    /**
-     * Adds a person to the list.
-     * The person must not already exist in the list.
-     */
-    public void add(Person toAdd) {
-        requireNonNull(toAdd);
-        if (contains(toAdd)) {
-            throw new DuplicatePersonException();
-        }
-        internalList.add(toAdd);
-    }
-
-    /**
-     * Replaces the person {@code target} in the list with {@code editedPerson}.
-     * {@code target} must exist in the list.
-     * The person identity of {@code editedPerson} must not be the same as another existing person in the list.
-     */
-    public void setPerson(Person target, Person editedPerson) {
-        requireAllNonNull(target, editedPerson);
-
-        int index = internalList.indexOf(target);
-        if (index == -1) {
-            throw new PersonNotFoundException();
-        }
-
-        if (!target.isSamePerson(editedPerson) && contains(editedPerson)) {
-            throw new DuplicatePersonException();
-        }
-
-        internalList.set(index, editedPerson);
-    }
-
-    /**
-     * Removes the equivalent person from the list.
-     * The person must exist in the list.
-     */
-    public void remove(Person toRemove) {
-        requireNonNull(toRemove);
-        if (!internalList.remove(toRemove)) {
-            throw new PersonNotFoundException();
-        }
-    }
-
-    public void setPersons(UniquePersonList replacement) {
-        requireNonNull(replacement);
-        internalList.setAll(replacement.internalList);
-    }
-
-    /**
-     * Replaces the contents of this list with {@code persons}.
-     * {@code persons} must not contain duplicate persons.
-     */
-    public void setPersons(List<Person> persons) {
-        requireAllNonNull(persons);
-        if (!personsAreUnique(persons)) {
-            throw new DuplicatePersonException();
-        }
-
-        internalList.setAll(persons);
-    }
-
-    /**
-     * Returns the backing list as an unmodifiable {@code ObservableList}.
-     */
-    public ObservableList<Person> asUnmodifiableObservableList() {
-        return internalUnmodifiableList;
+    @Override
+    protected boolean isSameItem(Person item1, Person item2) {
+        return item1.isSamePerson(item2);
     }
 
     @Override
-    public Iterator<Person> iterator() {
-        return internalList.iterator();
+    protected DuplicateItemException duplicateItemException() {
+        return new DuplicatePersonException();
     }
 
     @Override
-    public boolean equals(Object other) {
-        if (other == this) {
-            return true;
-        }
-
-        // instanceof handles nulls
-        if (!(other instanceof UniquePersonList)) {
-            return false;
-        }
-
-        UniquePersonList otherUniquePersonList = (UniquePersonList) other;
-        return internalList.equals(otherUniquePersonList.internalList);
-    }
-
-    @Override
-    public int hashCode() {
-        return internalList.hashCode();
-    }
-
-    @Override
-    public String toString() {
-        return internalList.toString();
-    }
-
-    /**
-     * Returns true if {@code persons} contains only unique persons.
-     */
-    private boolean personsAreUnique(List<Person> persons) {
-        for (int i = 0; i < persons.size() - 1; i++) {
-            for (int j = i + 1; j < persons.size(); j++) {
-                if (persons.get(i).isSamePerson(persons.get(j))) {
-                    return false;
-                }
-            }
-        }
-        return true;
+    protected ItemNotFoundException itemNotFoundException() {
+        return new PersonNotFoundException();
     }
 }
+

--- a/src/main/java/syncsquad/teamsync/model/person/UniquePersonList.java
+++ b/src/main/java/syncsquad/teamsync/model/person/UniquePersonList.java
@@ -1,8 +1,5 @@
 package syncsquad.teamsync.model.person;
 
-import static java.util.Objects.requireNonNull;
-import static syncsquad.teamsync.commons.util.CollectionUtil.requireAllNonNull;
-
 import syncsquad.teamsync.commons.exceptions.DuplicateItemException;
 import syncsquad.teamsync.commons.exceptions.ItemNotFoundException;
 import syncsquad.teamsync.model.UniqueItemList;

--- a/src/main/java/syncsquad/teamsync/model/person/exceptions/DuplicatePersonException.java
+++ b/src/main/java/syncsquad/teamsync/model/person/exceptions/DuplicatePersonException.java
@@ -1,10 +1,12 @@
 package syncsquad.teamsync.model.person.exceptions;
 
+import syncsquad.teamsync.commons.exceptions.DuplicateItemException;
+
 /**
  * Signals that the operation will result in duplicate Persons (Persons are considered duplicates if they have the same
  * identity).
  */
-public class DuplicatePersonException extends RuntimeException {
+public class DuplicatePersonException extends DuplicateItemException {
     public DuplicatePersonException() {
         super("Operation would result in duplicate persons");
     }

--- a/src/main/java/syncsquad/teamsync/model/person/exceptions/PersonNotFoundException.java
+++ b/src/main/java/syncsquad/teamsync/model/person/exceptions/PersonNotFoundException.java
@@ -1,6 +1,8 @@
 package syncsquad.teamsync.model.person.exceptions;
 
+import syncsquad.teamsync.commons.exceptions.ItemNotFoundException;
+
 /**
  * Signals that the operation is unable to find the specified person.
  */
-public class PersonNotFoundException extends RuntimeException {}
+public class PersonNotFoundException extends ItemNotFoundException {}

--- a/src/test/java/syncsquad/teamsync/model/meeting/UniqueMeetingListTest.java
+++ b/src/test/java/syncsquad/teamsync/model/meeting/UniqueMeetingListTest.java
@@ -66,38 +66,38 @@ public class UniqueMeetingListTest {
     }
 
     @Test
-    public void setMeetings_nullUniqueMeetingList_throwsNullPointerException() {
-        assertThrows(NullPointerException.class, () -> uniqueMeetingList.setMeetings((UniqueMeetingList) null));
+    public void setItems_nullUniqueMeetingList_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> uniqueMeetingList.setItems((UniqueMeetingList) null));
     }
 
     @Test
-    public void setMeetings_uniqueMeetingList_replacesOwnListWithProvidedUniqueMeetingList() {
+    public void setItems_uniqueMeetingList_replacesOwnListWithProvidedUniqueMeetingList() {
         uniqueMeetingList.add(JAN_MEETING);
         UniqueMeetingList expectedUniqueMeetingList = new UniqueMeetingList();
         expectedUniqueMeetingList.add(FEB_MEETING);
-        uniqueMeetingList.setMeetings(expectedUniqueMeetingList);
+        uniqueMeetingList.setItems(expectedUniqueMeetingList);
         assertEquals(expectedUniqueMeetingList, uniqueMeetingList);
     }
 
     @Test
-    public void setMeetings_nullList_throwsNullPointerException() {
-        assertThrows(NullPointerException.class, () -> uniqueMeetingList.setMeetings((List<Meeting>) null));
+    public void setItems_nullList_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> uniqueMeetingList.setItems((List<Meeting>) null));
     }
 
     @Test
-    public void setMeetings_list_replacesOwnListWithProvidedList() {
+    public void setItems_list_replacesOwnListWithProvidedList() {
         uniqueMeetingList.add(JAN_MEETING);
         List<Meeting> meetingList = Collections.singletonList(FEB_MEETING);
-        uniqueMeetingList.setMeetings(meetingList);
+        uniqueMeetingList.setItems(meetingList);
         UniqueMeetingList expectedUniqueMeetingList = new UniqueMeetingList();
         expectedUniqueMeetingList.add(FEB_MEETING);
         assertEquals(expectedUniqueMeetingList, uniqueMeetingList);
     }
 
     @Test
-    public void setMeetings_listWithDuplicateMeetings_throwsDuplicateMeetingException() {
+    public void setItems_listWithDuplicateMeetings_throwsDuplicateMeetingException() {
         List<Meeting> listWithDuplicateMeetings = Arrays.asList(JAN_MEETING, JAN_MEETING);
-        assertThrows(DuplicateMeetingException.class, () -> uniqueMeetingList.setMeetings(listWithDuplicateMeetings));
+        assertThrows(DuplicateMeetingException.class, () -> uniqueMeetingList.setItems(listWithDuplicateMeetings));
     }
 
     @Test

--- a/src/test/java/syncsquad/teamsync/model/person/UniquePersonListTest.java
+++ b/src/test/java/syncsquad/teamsync/model/person/UniquePersonListTest.java
@@ -59,54 +59,54 @@ public class UniquePersonListTest {
     }
 
     @Test
-    public void setPerson_nullTargetPerson_throwsNullPointerException() {
-        assertThrows(NullPointerException.class, () -> uniquePersonList.setPerson(null, ALICE));
+    public void setItem_nullTargetPerson_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> uniquePersonList.setItem(null, ALICE));
     }
 
     @Test
-    public void setPerson_nullEditedPerson_throwsNullPointerException() {
-        assertThrows(NullPointerException.class, () -> uniquePersonList.setPerson(ALICE, null));
+    public void setItem_nullEditedPerson_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> uniquePersonList.setItem(ALICE, null));
     }
 
     @Test
-    public void setPerson_targetPersonNotInList_throwsPersonNotFoundException() {
-        assertThrows(PersonNotFoundException.class, () -> uniquePersonList.setPerson(ALICE, ALICE));
+    public void setItem_targetPersonNotInList_throwsPersonNotFoundException() {
+        assertThrows(PersonNotFoundException.class, () -> uniquePersonList.setItem(ALICE, ALICE));
     }
 
     @Test
-    public void setPerson_editedPersonIsSamePerson_success() {
+    public void setItem_editedPersonIsSamePerson_success() {
         uniquePersonList.add(ALICE);
-        uniquePersonList.setPerson(ALICE, ALICE);
+        uniquePersonList.setItem(ALICE, ALICE);
         UniquePersonList expectedUniquePersonList = new UniquePersonList();
         expectedUniquePersonList.add(ALICE);
         assertEquals(expectedUniquePersonList, uniquePersonList);
     }
 
     @Test
-    public void setPerson_editedPersonHasSameIdentity_success() {
+    public void setItem_editedPersonHasSameIdentity_success() {
         uniquePersonList.add(ALICE);
         Person editedAlice = new PersonBuilder(ALICE).withAddress(VALID_ADDRESS_BOB)
                 .withTags(VALID_TAG_HUSBAND).build();
-        uniquePersonList.setPerson(ALICE, editedAlice);
+        uniquePersonList.setItem(ALICE, editedAlice);
         UniquePersonList expectedUniquePersonList = new UniquePersonList();
         expectedUniquePersonList.add(editedAlice);
         assertEquals(expectedUniquePersonList, uniquePersonList);
     }
 
     @Test
-    public void setPerson_editedPersonHasDifferentIdentity_success() {
+    public void setItem_editedPersonHasDifferentIdentity_success() {
         uniquePersonList.add(ALICE);
-        uniquePersonList.setPerson(ALICE, BOB);
+        uniquePersonList.setItem(ALICE, BOB);
         UniquePersonList expectedUniquePersonList = new UniquePersonList();
         expectedUniquePersonList.add(BOB);
         assertEquals(expectedUniquePersonList, uniquePersonList);
     }
 
     @Test
-    public void setPerson_editedPersonHasNonUniqueIdentity_throwsDuplicatePersonException() {
+    public void setItem_editedPersonHasNonUniqueIdentity_throwsDuplicatePersonException() {
         uniquePersonList.add(ALICE);
         uniquePersonList.add(BOB);
-        assertThrows(DuplicatePersonException.class, () -> uniquePersonList.setPerson(ALICE, BOB));
+        assertThrows(DuplicatePersonException.class, () -> uniquePersonList.setItem(ALICE, BOB));
     }
 
     @Test
@@ -128,38 +128,38 @@ public class UniquePersonListTest {
     }
 
     @Test
-    public void setPersons_nullUniquePersonList_throwsNullPointerException() {
-        assertThrows(NullPointerException.class, () -> uniquePersonList.setPersons((UniquePersonList) null));
+    public void setItems_nullUniquePersonList_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> uniquePersonList.setItems((UniquePersonList) null));
     }
 
     @Test
-    public void setPersons_uniquePersonList_replacesOwnListWithProvidedUniquePersonList() {
+    public void setItems_uniquePersonList_replacesOwnListWithProvidedUniquePersonList() {
         uniquePersonList.add(ALICE);
         UniquePersonList expectedUniquePersonList = new UniquePersonList();
         expectedUniquePersonList.add(BOB);
-        uniquePersonList.setPersons(expectedUniquePersonList);
+        uniquePersonList.setItems(expectedUniquePersonList);
         assertEquals(expectedUniquePersonList, uniquePersonList);
     }
 
     @Test
-    public void setPersons_nullList_throwsNullPointerException() {
-        assertThrows(NullPointerException.class, () -> uniquePersonList.setPersons((List<Person>) null));
+    public void setItems_nullList_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> uniquePersonList.setItems((List<Person>) null));
     }
 
     @Test
-    public void setPersons_list_replacesOwnListWithProvidedList() {
+    public void setItems_list_replacesOwnListWithProvidedList() {
         uniquePersonList.add(ALICE);
         List<Person> personList = Collections.singletonList(BOB);
-        uniquePersonList.setPersons(personList);
+        uniquePersonList.setItems(personList);
         UniquePersonList expectedUniquePersonList = new UniquePersonList();
         expectedUniquePersonList.add(BOB);
         assertEquals(expectedUniquePersonList, uniquePersonList);
     }
 
     @Test
-    public void setPersons_listWithDuplicatePersons_throwsDuplicatePersonException() {
+    public void setItems_listWithDuplicatePersons_throwsDuplicatePersonException() {
         List<Person> listWithDuplicatePersons = Arrays.asList(ALICE, ALICE);
-        assertThrows(DuplicatePersonException.class, () -> uniquePersonList.setPersons(listWithDuplicatePersons));
+        assertThrows(DuplicatePersonException.class, () -> uniquePersonList.setItems(listWithDuplicatePersons));
     }
 
     @Test


### PR DESCRIPTION
Fixes #140 

`UniqueMeetingList` and `UniquePersonList` has been refactored to inherit from an abstract class `UniqueItemList`

Proposed commit message:
```
Extract common operations in UniqueMeetingList and UniquePersonList.

Let's refactor UniqueMeetingList and UniquePersonList to inherit from
an abstract class UniqueItemList.

This reduces code duplication.
```