### PR TITLE
Fix DeleteModuleCommandParser validation

### DIFF
--- a/src/main/java/syncsquad/teamsync/logic/parser/module/DeleteModuleCommandParser.java
+++ b/src/main/java/syncsquad/teamsync/logic/parser/module/DeleteModuleCommandParser.java
@@ -23,6 +23,10 @@ public class DeleteModuleCommandParser implements Parser<DeleteModuleCommand> {
         try {
             args = args.trim();
             String[] params = args.split(" ");
+            if (params.length != 2) {
+                throw new ParseException(
+                        String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteModuleCommand.MESSAGE_USAGE));
+            }
             Index index = ParserUtil.parseIndex(params[0]);
             ModuleCode moduleCode = ParserUtil.parseModuleCode(params[1]);
             return new DeleteModuleCommand(index, moduleCode);


### PR DESCRIPTION
Fixes #233 

"module delete 1" failed silently, fixed to catch the error when user does not specify module code to delete